### PR TITLE
Don't silently fail and try to carry on if s3 connection response fails

### DIFF
--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -318,12 +318,10 @@ class DDSBaseClass:
 
         else:
             # Printout if no cancelled/failed files
-            console.print(f"\n{'Upload' if self.method == 'put' else 'Download'} completed!\n")
+            LOG.debug(f"\n{'Upload' if self.method == 'put' else 'Download'} completed!\n")
 
         if self.method == "get" and len(self.filehandler.data) > len(any_failed):
-            console.print(
-                f"Any downloaded files are located: {self.filehandler.local_destination}."
-            )
+            LOG.info(f"Any downloaded files are located: {self.filehandler.local_destination}.")
 
     def __collect_all_failed(self, sort: bool = True):
         """Put cancelled files from status in to failed dict and sort the output."""

--- a/dds_cli/cli_decorators.py
+++ b/dds_cli/cli_decorators.py
@@ -91,7 +91,7 @@ def update_status(func):
 
         # Update status to started
         self.status[file][func.__name__].update({"started": True})
-        LOG.info(f"File {file} status updated to {func.__name__}: started")
+        LOG.debug(f"File {file} status updated to {func.__name__}: started")
 
         # Run function
         ok_to_continue, message, *_ = func(self, file=file, *args, **kwargs)
@@ -105,7 +105,7 @@ def update_status(func):
         else:
             # Update status to done
             self.status[file][func.__name__].update({"done": True})
-            LOG.info(f"File {file} status updated to {func.__name__}: done")
+            LOG.debug(f"File {file} status updated to {func.__name__}: done")
 
         return ok_to_continue, message
 
@@ -135,7 +135,7 @@ def connect_cloud(func):
                 f"S3 connection failed: {err}",
             )
         else:
-            LOG.info("Connection to S3 established.")
+            LOG.debug("Connection to S3 established.")
             return func(self, *args, **kwargs)
 
     return init_resource

--- a/dds_cli/data_putter.py
+++ b/dds_cli/data_putter.py
@@ -117,7 +117,7 @@ def put(
                             # Get result
                             try:
                                 file_uploaded = fut.result()
-                                LOG.info(f"Upload of {uploaded_file} successful: {file_uploaded}")
+                                LOG.debug(f"Upload of {uploaded_file} successful: {file_uploaded}")
                             except concurrent.futures.BrokenExecutor as err:
                                 LOG.error(f"Upload of file {uploaded_file} failed! Error: {err}")
                                 continue

--- a/dds_cli/file_encryptor.py
+++ b/dds_cli/file_encryptor.py
@@ -186,7 +186,7 @@ class Encryptor(ECDHKeyHandler):
         else:
             encrypted_and_saved = True
             message = f"Encrypted file stored in location: {outfile}"
-            LOG.info(message)
+            LOG.debug(message)
         finally:
             os.umask(original_umask)
 

--- a/dds_cli/s3_connector.py
+++ b/dds_cli/s3_connector.py
@@ -87,14 +87,9 @@ class S3Connector:
             raise SystemExit from err
 
         # Error
-        if not response.ok:
-            return (
-                sfsp_proj,
-                keys,
-                url,
-                bucket,
-                f"Failed retrieving Safespring project name: {response.text}",
-            )
+        assert (
+            response.ok
+        ), f"Failed retrieving Safespring project name. Server response: {response.text}"
 
         # Get s3 info
         try:


### PR DESCRIPTION
To be taken together with https://github.com/ScilifelabDataCentre/dds_web/pull/465 on `dds_web`.

Instead of continuing execution if the server does not return the required s3 connection details, `assert` it and raise an exception if something is wrong.

Together with the web PR, I now get this:

```python
Traceback (most recent call last):
  File "/Users/ewels/miniconda3/envs/py3/bin/dds", line 33, in <module>
    sys.exit(load_entry_point('dds-cli', 'console_scripts', 'dds')())
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/__main__.py", line 209, in put
    silent,
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/data_putter.py", line 64, in put
    silent=silent,
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/data_putter.py", line 215, in __init__
    self.verify_bucket_exist()
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/base.py", line 370, in verify_bucket_exist
    with s3.S3Connector(project_id=self.project, token=self.token) as conn:
  File "<string>", line 3, in __init__
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/s3_connector.py", line 55, in __post_init__
    ) = self.get_s3_info(project_id=project_id, token=token)
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/s3_connector.py", line 92, in get_s3_info
    ), f"Failed retrieving Safespring project name. Server response: {response.text}"
AssertionError: Failed retrieving Safespring project name. Server response: {
    "message": "[Errno 2] No such file or directory: '/code/dds_web/s3_config_example.json'"
}
```

Messy - but it's a bit of an edge case error which is critical and importantly the final lines tell me quite quickly and succinctly what went wrong (would be fairly easy to catch `AssertionError`s at the top cli level in `__main__` and print the messages without the traceback, might add that separately).

Before these two PRs I was getting this traceback instead:

```python
Traceback (most recent call last):
  File "/Users/ewels/miniconda3/envs/py3/bin/dds", line 33, in <module>
    sys.exit(load_entry_point('dds-cli', 'console_scripts', 'dds')())
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ewels/miniconda3/envs/py3/lib/python3.7/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/__main__.py", line 209, in put
    silent,
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/data_putter.py", line 64, in put
    silent=silent,
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/data_putter.py", line 215, in __init__
    self.verify_bucket_exist()
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/base.py", line 370, in verify_bucket_exist
    with s3.S3Connector(project_id=self.project, token=self.token) as conn:
  File "/Users/ewels/GitHub/SciLifeLab/dds_cli/dds_cli/cli_decorators.py", line 128, in init_resource
    aws_access_key_id=self.keys["access_key"],
TypeError: 'NoneType' object is not subscriptable
```

Which had me scratching my head for a little while 😉  Better a useful traceback at the point of error than weird unexpected side effects causing unhelpful tracebacks..