### PR TITLE
`dds ls` usability improvements

### DIFF
--- a/dds_cli/__init__.py
+++ b/dds_cli/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 import pkg_resources
+import prompt_toolkit
 
 ###############################################################################
 # PROJECT SPEC ################################################# PROJECT SPEC #
@@ -69,3 +70,23 @@ class FileSegment:
     DDS_SIGNATURE = b"DelSys"
     SEGMENT_SIZE_RAW = 65536  # Size of chunk to read from raw file
     SEGMENT_SIZE_CIPHER = SEGMENT_SIZE_RAW + 16  # Size of chunk to read from encrypted file
+
+
+# Custom styles for questionary
+dds_questionary_styles = prompt_toolkit.styles.Style(
+    [
+        ("qmark", "fg:ansiblue bold"),  # token in front of the question
+        ("question", "bold"),  # question text
+        ("answer", "fg:ansigreen nobold bg:"),  # submitted answer text behind the question
+        ("pointer", "fg:ansiyellow bold"),  # pointer used in select and checkbox prompts
+        ("highlighted", "fg:ansiblue bold"),  # pointed-at choice in select and checkbox prompts
+        ("selected", "fg:ansiyellow noreverse bold"),  # style for a selected item of a checkbox
+        ("separator", "fg:ansiblack"),  # separator in lists
+        ("instruction", ""),  # user instructions for select, rawselect, checkbox
+        ("text", ""),  # plain text
+        ("disabled", "fg:gray italic"),  # disabled choices for select and checkbox prompts
+        ("choice-default", "fg:ansiblack"),
+        ("choice-default-changed", "fg:ansiyellow"),
+        ("choice-required", "fg:ansired"),
+    ]
+)

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -222,6 +222,7 @@ def put(
 @dds_main.command()
 @click.argument("project", metavar="[PROJECT ID]", nargs=1, required=False)
 @click.argument("folder", nargs=1, required=False)
+@click.option("--projects", "-lp", is_flag=True, help="List all project connected to your account.")
 @click.option("--size", "-s", is_flag=True, default=False, help="Show size of project contents.")
 @click.option(
     "--username", "-u", required=False, type=str, help="Your Data Delivery System username."
@@ -234,7 +235,7 @@ def put(
     help="Path to file with user credentials, destination, etc.",
 )
 @click.pass_obj
-def ls(dds_info, project, folder, size, username, config):
+def ls(dds_info, project, folder, projects, size, username, config):
     """
     List your projects and project files.
 
@@ -252,7 +253,7 @@ def ls(dds_info, project, folder, size, username, config):
         if project is None:
             with dds_cli.data_lister.DataLister(
                 project=project,
-                project_level=project is None,
+                project_level=project is None or projects,
                 config=dds_info["CONFIG"] if config is None else config,
                 username=username,
             ) as lister:

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -16,6 +16,7 @@ from logging.config import dictConfig
 # Installed
 import click
 import click_pathlib
+import questionary
 import rich
 import rich.console
 import rich.logging
@@ -247,17 +248,79 @@ def ls(dds_info, project, folder, size, username, config):
         LOG.warning("NB! Listing the project size is not yet implemented.")
 
     try:
-        with dds_cli.data_lister.DataLister(
-            project=project,
-            project_level=project is None,
-            config=dds_info["CONFIG"] if config is None else config,
-            username=username,
-        ) as lister:
-            # List all projects if project is None and all files if project spec
-            if lister.project is None:
-                lister.list_projects()
-            if lister.project:
-                lister.list_files(folder=folder, show_size=size)
+        # List all projects if project is None and all files if project spec
+        if project is None:
+            with dds_cli.data_lister.DataLister(
+                project=project,
+                project_level=project is None,
+                config=dds_info["CONFIG"] if config is None else config,
+                username=username,
+            ) as lister:
+                projects = lister.list_projects()
+
+                # If an interactive terminal, ask user if they want to view files for a project
+                if sys.stdout.isatty():
+                    project_ids = [p["Project ID"] for p in projects]
+                    LOG.info(
+                        "Would you like to view files in a specific project? Leave blank to exit."
+                    )
+                    # Keep asking until we get a valid response
+                    while project not in project_ids:
+                        try:
+                            project = questionary.autocomplete(
+                                "Project ID:",
+                                choices=project_ids,
+                                validate=lambda x: x in project_ids or x == "",
+                                style=dds_cli.dds_questionary_styles,
+                            ).unsafe_ask()
+                            assert project != ""
+                            assert project is not None
+                        # If didn't enter anything, convert to None and exit
+                        except (KeyboardInterrupt, AssertionError):
+                            break
+
+        # List all files in a project if we know a project ID
+        if project:
+            with dds_cli.data_lister.DataLister(
+                project=project,
+                project_level=project is None,
+                config=dds_info["CONFIG"] if config is None else config,
+                username=username,
+            ) as lister:
+                folders = lister.list_files(folder=folder, show_size=size)
+
+                # If an interactive terminal, ask user if they want to view files for a project
+                if sys.stdout.isatty():
+                    LOG.info(
+                        "Would you like to view files within a directory? Leave blank to exit."
+                    )
+                    last_folder = None
+                    while folder is None or folder != last_folder:
+                        last_folder = folder
+
+                        if not len(folders):
+                            break
+
+                        try:
+                            folder = questionary.autocomplete(
+                                "Folder:",
+                                choices=folders,
+                                validate=lambda x: x in folders or x == "",
+                                style=dds_cli.dds_questionary_styles,
+                            ).unsafe_ask()
+                            assert folder != ""
+                            assert folder is not None
+                        # If didn't enter anything, convert to None and exit
+                        except (KeyboardInterrupt, AssertionError):
+                            break
+
+                        # Prepend existing file path
+                        if last_folder is not None and folder is not None:
+                            folder = os.path.join(last_folder, folder)
+
+                        # List files
+                        folders = lister.list_files(folder=folder, show_size=size)
+
     except (dds_cli.exceptions.NoDataError) as e:
         LOG.warning(e)
         sys.exit(0)

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -47,7 +47,7 @@ LOG = logging.getLogger()
 # Print header to STDERR
 stderr = rich.console.Console(stderr=True)
 stderr.print(
-    "\n\n[green]     ︵",
+    "[green]     ︵",
     "\n[green] ︵ (  )   ︵",
     "\n[green](  ) ) (  (  )[/]   [bold]SciLifeLab Data Delivery System",
     "\n[green] ︶  (  ) ) ([/]    [blue][link={0}]{0}[/link]".format(dds_cli.__url__),
@@ -219,14 +219,9 @@ def put(
 
 
 @dds_main.command()
-@click.argument("fold_arg", required=False)  # Needs to be before proj_arg
-@click.argument("proj_arg", required=False)
-@click.option("--project", "-p", required=False, help="Project ID.")
-@click.option("--projects", "-lp", is_flag=True, help="List all project connected to your account.")
-@click.option(
-    "--folder", "-fl", required=False, multiple=False, help="Folder to list files within."
-)
-@click.option("--size", "-sz", is_flag=True, default=False, help="Show size of project contents.")
+@click.argument("project", metavar="[PROJECT ID]", nargs=1, required=False)
+@click.argument("folder", nargs=-1)
+@click.option("--size", "-s", is_flag=True, default=False, help="Show size of project contents.")
 @click.option(
     "--username", "-u", required=False, type=str, help="Your Data Delivery System username."
 )
@@ -238,19 +233,23 @@ def put(
     help="Path to file with user credentials, destination, etc.",
 )
 @click.pass_obj
-def ls(dds_info, proj_arg, fold_arg, project, projects, folder, size, username, config):
-    """List the projects and the files within the projects."""
+def ls(dds_info, project, folder, size, username, config):
+    """
+    List your projects and project files.
 
-    project = proj_arg if proj_arg is not None else project
-    folder = fold_arg if fold_arg is not None else folder
+    To list all projects, run `dds ls` without any arguments.
 
-    if projects and size:
+    Specify a Project ID to list the files within a project.
+    You can also follow this with a subfolder path to show files within that folder.
+    """
+
+    if not project and size:
         LOG.warning("NB! Listing the project size is not yet implemented.")
 
     try:
         with dds_cli.data_lister.DataLister(
             project=project,
-            project_level=projects,
+            project_level=project is None,
             config=dds_info["CONFIG"] if config is None else config,
             username=username,
         ) as lister:

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -220,7 +220,7 @@ def put(
 
 @dds_main.command()
 @click.argument("project", metavar="[PROJECT ID]", nargs=1, required=False)
-@click.argument("folder", nargs=-1)
+@click.argument("folder", nargs=1, required=False)
 @click.option("--size", "-s", is_flag=True, default=False, help="Show size of project contents.")
 @click.option(
     "--username", "-u", required=False, type=str, help="Your Data Delivery System username."
@@ -256,7 +256,7 @@ def ls(dds_info, project, folder, size, username, config):
             # List all projects if project is None and all files if project spec
             if lister.project is None:
                 lister.list_projects()
-            else:
+            if lister.project:
                 lister.list_files(folder=folder, show_size=size)
     except (dds_cli.exceptions.NoDataError) as e:
         LOG.warning(e)

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -147,13 +147,6 @@ class DDSBaseClass:
                 username = contents["username"]
             if password is None and "password" in contents:
                 password = contents["password"]
-            # if not ignore_config_project:
-            #     if (
-            #         project is None
-            #         and "project" in contents
-            #         and self.method in ["put", "get", "ls"]
-            #     ):
-            #         project = contents["project"]
 
         LOG.debug(f"Username: {username}, Project ID: {project}")
 

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -142,18 +142,18 @@ class DDSBaseClass:
             # Get contents from file
             contents = fh.FileHandler.extract_config(configfile=config)
 
-            # Get user credentials and project info if not already specified
+            # Get user credentials if not already specified
             if username is None and "username" in contents:
                 username = contents["username"]
             if password is None and "password" in contents:
                 password = contents["password"]
-            if not ignore_config_project:
-                if (
-                    project is None
-                    and "project" in contents
-                    and self.method in ["put", "get", "ls"]
-                ):
-                    project = contents["project"]
+            # if not ignore_config_project:
+            #     if (
+            #         project is None
+            #         and "project" in contents
+            #         and self.method in ["put", "get", "ls"]
+            #     ):
+            #         project = contents["project"]
 
         LOG.debug(f"Username: {username}, Project ID: {project}")
 

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -7,14 +7,12 @@
 # Standard library
 import logging
 import pathlib
-import sys
 
 # Installed
 import requests
 import simplejson
 from rich.console import Console
 from rich.padding import Padding
-from rich.prompt import Confirm
 from rich.table import Table
 from rich.tree import Tree
 
@@ -59,7 +57,7 @@ class DataLister(base.DDSBaseClass):
             raise exceptions.AuthenticationError(f"Unauthorized method: '{self.method}'")
 
     # Public methods ########################### Public methods #
-    def list_projects(self):
+    def list_projects(self, prompt_project=False):
         """Gets a list of all projects the user is involved in."""
 
         # Get projects from API
@@ -110,7 +108,7 @@ class DataLister(base.DDSBaseClass):
         # Print to stdout if there are any lines
         if table.columns:
             # Use a pager if output is taller than the visible terminal
-            if len(resp_json["all_projects"]) + 5 > console.height:
+            if len(sorted_projects) + 5 > console.height:
                 with console.pager():
                     console.print(table)
             else:
@@ -118,14 +116,15 @@ class DataLister(base.DDSBaseClass):
         else:
             raise exceptions.NoDataError(f"No projects found")
 
+        # Return the list of projects
+        return sorted_projects
+
     def list_files(self, folder: str = None, show_size: bool = False):
         """Create a tree displaying the files within the project."""
 
         LOG.info(f"Listing files for project '{self.project}'")
         if folder:
             LOG.info(f"Showing files in folder '{folder}'")
-
-        console = Console()
 
         # Make call to API
         try:
@@ -135,16 +134,16 @@ class DataLister(base.DDSBaseClass):
                 headers=self.token,
             )
         except requests.exceptions.RequestException as err:
-            raise exceptions.APIError(f"Problem with database response: {err}")
+            raise exceptions.APIError(f"Problem with database response: '{err}'")
 
         if not response.ok:
-            raise exceptions.APIError(f"Failed to get list of files: {response.text}")
+            raise exceptions.APIError(f"Failed to get list of files: '{response.text}'")
 
         # Get response
         try:
             resp_json = response.json()
         except simplejson.JSONDecodeError as err:
-            raise exceptions.APIError(f"Could not decode JSON response: {err}")
+            raise exceptions.APIError(f"Could not decode JSON response: '{err}'")
 
         # Check if project empty
         if "num_items" in resp_json and resp_json["num_items"] == 0:
@@ -154,52 +153,61 @@ class DataLister(base.DDSBaseClass):
         files_folders = resp_json["files_folders"]
 
         # Sort the file/folders according to names
-        sorted_projects = sorted(files_folders, key=lambda f: f["name"])
+        sorted_files_folders = sorted(files_folders, key=lambda f: f["name"])
 
         # Create tree
         tree_title = folder if folder else f"Files / directories in project: [green]{self.project}"
         tree = Tree(f"[bold magenta]{tree_title}")
 
-        if sorted_projects:
-            # Get max length of file name
-            max_string = max([len(x["name"]) for x in sorted_projects])
+        if not sorted_files_folders:
+            raise exceptions.NoDataError(f"Could not find folder: '{folder}'")
 
-            # Get max length of size string
-            sizes = [len(x["size"][0]) for x in sorted_projects if show_size and "size" in x]
-            max_size = max(sizes) if sizes else 0
+        # Get max length of file name
+        max_string = max([len(x["name"]) for x in sorted_files_folders])
 
-            # Add items to tree
-            for x in sorted_projects:
-                # Check if string is folder
-                is_folder = x.pop("folder")
+        # Get max length of size string
+        sizes = [len(x["size"][0]) for x in sorted_files_folders if show_size and "size" in x]
+        max_size = max(sizes) if sizes else 0
 
-                # Att 1 for folders due to trailing /
-                tab = th.TextHandler.format_tabs(
-                    string_len=len(x["name"]) + (1 if is_folder else 0),
-                    max_string_len=max_string,
+        # Visible folders
+        visible_folders = []
+
+        # Add items to tree
+        for x in sorted_files_folders:
+            # Check if string is folder
+            is_folder = x.pop("folder")
+
+            # Att 1 for folders due to trailing /
+            tab = th.TextHandler.format_tabs(
+                string_len=len(x["name"]) + (1 if is_folder else 0),
+                max_string_len=max_string,
+            )
+
+            # Add formatting if folder and set string name
+            line = ""
+            if is_folder:
+                line = "[bold deep_sky_blue3]"
+                visible_folders.append(x["name"])
+            line += x["name"] + ("/" if is_folder else "")
+
+            # Add size to line if option specified
+            if show_size and "size" in x:
+                line += f"{tab}{x['size'][0]}"
+
+                # Define space between number and size format
+                tabs_bf_format = th.TextHandler.format_tabs(
+                    string_len=len(x["size"][0]), max_string_len=max_size, tab_len=2
                 )
+                line += f"{tabs_bf_format}{x['size'][1]}"
+            tree.add(line)
 
-                # Add formatting if folder and set string name
-                line = ""
-                if is_folder:
-                    line = "[bold deep_sky_blue3]"
-                line += x["name"] + ("/" if is_folder else "")
-
-                # Add size to line if option specified
-                if show_size and "size" in x:
-                    line += f"{tab}{x['size'][0]}"
-
-                    # Define space between number and size format
-                    tabs_bf_format = th.TextHandler.format_tabs(
-                        string_len=len(x["size"][0]), max_string_len=max_size, tab_len=2
-                    )
-                    line += f"{tabs_bf_format}{x['size'][1]}"
-                tree.add(line)
-
-            if len(files_folders) + 5 > console.height:
-                with console.pager():
-                    console.print(Padding(tree, 1))
-            else:
+        # Print output to stdout
+        console = Console()
+        if len(files_folders) + 5 > console.height:
+            with console.pager():
                 console.print(Padding(tree, 1))
         else:
-            raise exceptions.NoDataError(f"Could not find folder folder: '{folder}'")
+            console.print(Padding(tree, 1))
+
+        # Return variable
+        return visible_folders

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ cryptography>=3.3.2
 immutabledict
 pandas>=1.2.0
 prettytable>=2.0.0
+prompt_toolkit>=3.0.3
 PyNaCl>=1.4.0
+questionary>=1.8.0
 requests>=2.25.1
 rich>=10.0.0
 simplejson


### PR DESCRIPTION
Work in progress, trying to make the `dds ls` command easier to use (from my perspective) and a bit fancier.

Will add to this list as I go and mark as ready to review when I think the PR has enough :)

* Clean up command line flags
    * Positional only for project and folder (reversed order)
    * `--projects` removed and inferred by lack of specified `project`
    * More cli help text
* Instead of warning if there is a lot of output, automatically page the output
    * Use the [`rich` console pager](https://rich.readthedocs.io/en/stable/console.html#paging)
    * Base the decision on the height of the user's terminal, not an arbitrary count
    * Non-interactive usage (eg. piping / redirecting to a file) will still have normal behaviour
* Prompt for a project to view files for
    * After printing table of projects, use [Questionary to prompt](https://questionary.readthedocs.io/en/stable/pages/types.html#autocomplete) for a project ID to show the files for
    * Only prompts if the console is running interactively (eg. not redirection)
    * Live validation of entered text against possible project IDs
* Prompt for a folder to view files inside
    * After listing files, prompt for a subfolder to view
    * Only prompts if console is interactive
    * Only prompts if there is a folder in the list
    * _Note: It would be nicer to be able to use the [Questionary File Path](https://questionary.readthedocs.io/en/stable/pages/types.html#file-path) prompt and to be able to tab through subdirectories. Currently the website does not return a recursive file listing though, so this isn't possible._