### PR TITLE
Remove call to deprecated `warn_if_many`

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -410,10 +410,10 @@ def rm(dds_info, proj_arg, project, username, rm_all, file, folder, config):
         if rm_all:
             remover.remove_all()
 
-        if file:
+        elif file:
             remover.remove_file(files=file)
 
-        if folder:
+        elif folder:
             remover.remove_folder(folder=folder)
 
 

--- a/dds_cli/cli_decorators.py
+++ b/dds_cli/cli_decorators.py
@@ -13,6 +13,8 @@ import pathlib
 import boto3
 import botocore
 import rich
+import rich.padding
+import rich.table
 from rich.progress import Progress, SpinnerColumn
 
 # Own modules
@@ -204,6 +206,23 @@ def removal_spinner(func):
             message = f"{rm_type}(s) successfully removed."
 
         console = rich.console.Console()
-        console.print(message)
+
+        # Compute size of table
+        if isinstance(message, rich.padding.Padding) and isinstance(
+            message.renderable, rich.table.Table
+        ):
+            table_len = message.renderable.row_count + message.top + message.bottom
+        elif isinstance(message, rich.table.Table):
+            table_len = message.row_count
+        else:
+            # The message is probably not a table and should
+            # therefore be printed directly
+            table_len = 0
+
+        if table_len + 5 > console.height:
+            with console.pager():
+                console.print(message)
+        else:
+            console.print(message)
 
     return create_and_remove_task

--- a/dds_cli/data_remover.py
+++ b/dds_cli/data_remover.py
@@ -12,12 +12,13 @@ import sys
 # Installed
 import requests
 import rich
+import rich.table
+import rich.padding
 import simplejson
 
 # Own modules
 from dds_cli.cli_decorators import removal_spinner
 from dds_cli import base
-from dds_cli import data_lister
 from dds_cli import DDSEndpoint
 
 ###############################################################################
@@ -61,8 +62,6 @@ class DataRemover(base.DDSBaseClass):
 
         # Create table if any files failed
         if not_exists or delete_failed:
-            # Warn if many failed files
-            data_lister.DataLister.warn_if_many(count=len(not_exists) + len(delete_failed))
 
             # Create table and add columns
             table = rich.table.Table(
@@ -76,14 +75,14 @@ class DataRemover(base.DDSBaseClass):
                 table.add_column(x)
 
             # Add rows
-            _ = [table.add_row(x, f"No such {level.lower()}") for x in not_exists]
-            _ = [
+            for x in not_exists:
+                table.add_row(x, f"No such {level.lower()}")
+
+            for x, y in delete_failed.items():
                 table.add_row(
                     f"[light_salmon3]{x}[/light_salmon3]",
                     f"[light_salmon3]{y}[/light_salmon3]",
                 )
-                for x, y in delete_failed.items()
-            ]
 
             # Print out table
             return rich.padding.Padding(table, 1)


### PR DESCRIPTION
Replaced call to the removed `warn_if_many` function from `data_lister.py` with pagination of tables if they are too long.  Should close #128.