### PR TITLE
Log errors for upload directly

### DIFF
--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -101,13 +101,12 @@ class DDSBaseClass:
         return self
 
     def __exit__(self, exc_type, exc_value, tb, max_fileerrs: int = 40):
-
-        # Don't clean up if we hit an exception
-        if exc_type is not None:
-            return False
-
         if self.method in ["put", "get"]:
             self.__printout_delivery_summary()
+
+        # Exception is not handled
+        if exc_type is not None:
+            return False
 
         return True
 

--- a/dds_cli/cli_decorators.py
+++ b/dds_cli/cli_decorators.py
@@ -20,6 +20,7 @@ from rich.progress import Progress, SpinnerColumn
 # Own modules
 import dds_cli
 import dds_cli.utils
+import dds_cli.file_handler
 
 ###############################################################################
 # START LOGGING CONFIG ################################# START LOGGING CONFIG #
@@ -75,7 +76,9 @@ def verify_proceed(func):
                     for x in self.status
                     if not self.status[x]["cancel"] and not self.status[x]["started"] and x != file
                 ]
-
+            dds_cli.file_handler.FileHandler.append_errors_to_file(
+                self.failed_delivery_log, self.status[file]
+            )
         return ok_to_proceed
 
     return wrapped
@@ -103,6 +106,7 @@ def update_status(func):
         # ok_to_continue = False
         if not ok_to_continue:
             # Save info about which operation failed
+
             self.status[file]["failed_op"] = func.__name__
             LOG.warning(f"{func.__name__} failed: {message}")
 

--- a/dds_cli/data_putter.py
+++ b/dds_cli/data_putter.py
@@ -296,13 +296,13 @@ class DataPutter(base.DDSBaseClass):
             # Perform upload
             file_uploaded, message = self.put(file=file, progress=progress, task=task)
 
-            LOG.debug(f"File uploaded: {file_uploaded}")
             # Perform db update
             if file_uploaded:
                 db_updated, message = self.add_file_db(file=file)
 
                 if db_updated:
                     all_ok = True
+                    LOG.info(f"File successfully uploaded and added to the database: {file}")
 
         if not saved or all_ok:
             # Delete temporary processed file locally
@@ -364,7 +364,7 @@ class DataPutter(base.DDSBaseClass):
                     TypeError,
                 ) as err:
                     error = f"S3 upload of file '{file}' failed: {err}"
-                    LOG.exceptionf("{file}: {err}")
+                    LOG.exception(f"{file}: {err}")
                 else:
                     uploaded = True
 

--- a/dds_cli/file_handler.py
+++ b/dds_cli/file_handler.py
@@ -84,15 +84,18 @@ class FileHandler:
         return contents
 
     @staticmethod
-    def save_errors_to_file(file: pathlib.Path, info):
+    def append_errors_to_file(file: pathlib.Path, info):
         try:
             original_umask = os.umask(0)  # User file-creation mode mask
-            with file.open(mode="w") as errfile:
-                json.dump(
+            with file.open(mode="a") as errfile:
+                json_output = json.dumps(
                     info,
-                    errfile,
-                    indent=4,
+                    indent=None,
                 )
+                # Each line is valid json, but the entire file is not.
+                # Multiple threads are appending to this file, so valid json for
+                # the entire file is not trivial.
+                errfile.write(json_output + "\n")
         except (OSError, TypeError) as err:
             LOG.warning(str(err))
         finally:


### PR DESCRIPTION
Errors are now logged more or less directly after failure upon exiting the `verify_proceed` wrapper. Since multiple threads could be appending lines to the log, I changed the format of the log so that each line is valid json but the entire file is unfortunately not. Parsing should be easy enough just reading line by line.

I ran 32 threads (on my laptop though) and multiple threads appending to the file did not cause any issues, but I'm not sure it's a recommended praxis. Safer would be to have a single thread taking care of the logging or keeping a global lock variable in the owning class perhaps.

However, I think there might be better ways of making sure that the bucket and database is in sync which seems to be the ultimate goal of this log.