### PR TITLE
Abspath instead of resolve

### DIFF
--- a/dds_cli/file_handler_local.py
+++ b/dds_cli/file_handler_local.py
@@ -147,9 +147,16 @@ class LocalFileHandler(fh.FileHandler):
                 file_info.update({**content_info})
             else:
                 if path.is_symlink():
-                    LOG.warning(
-                        f"IGNORED: Link: {path} -> {path.resolve()} seems to be broken, will be ignored."
-                    )
+                    try:
+                        resolved = path.resolve()
+                    except RuntimeError:
+                        LOG.warning(
+                            f"IGNORED: Link: {path} seems to contain infinite loop, will be ignored."
+                        )
+                    else:
+                        LOG.warning(
+                            f"IGNORED: Link: {path} -> {resolved} seems to be broken, will be ignored."
+                        )
                 else:
                     LOG.warning(
                         f"IGNORED: Path of unsupported/unknown type: {path}, will be ignored."


### PR DESCRIPTION
Resolve would a source link to be uploaded with the name of what the link is pointing to and not the name of the link. I think the name of the link is what we should have.

A good test case is the following structure:

```
mkdir dir_with_contents
touch dir_with_contents/simple_file.txt
ln -s dir_with_contents dir_that_is_a_link
dds put -u unituser_1 -p project_1 -s dir_that_is_a_link
dds get -u unituser_1 -p project_1 -a
```

Prior to this PR the downloaded data would be inside `files/dir_with_contents` and after this PR it would be `files/dir_that_is_a_link`.
