### PR TITLE
Some refactoring of `dds rm` and config finding/parsing errors

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -79,6 +79,7 @@ def dds_main(ctx, verbose, log_file):
                 console=dds_cli.utils.console,
                 show_time=False,
                 markup=True,
+                show_path=verbose,
             )
         )
 

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -385,12 +385,12 @@ def rm(dds_info, proj_arg, project, username, rm_all, file, folder, config):
     # One of proj_arg or project is required
     if all(x is None for x in [proj_arg, project]):
         LOG.error("No project specified, cannot remove anything.")
-        os._exit(1)
+        sys.exit(1)
 
     # Either all or a file
     if rm_all and (file or folder):
         LOG.error("The options '--rm-all' and '--file'/'--folder' cannot be used together.")
-        os._exit(1)
+        sys.exit(1)
 
     project = proj_arg if proj_arg is not None else project
 
@@ -399,7 +399,7 @@ def rm(dds_info, proj_arg, project, username, rm_all, file, folder, config):
         LOG.error(
             "One of the options must be specified to perform data deletion: '--rm-all' / '--file' / '--folder'."
         )
-        os._exit(1)
+        sys.exit(1)
 
     # Warn if trying to remove all contents
     if rm_all:
@@ -407,22 +407,26 @@ def rm(dds_info, proj_arg, project, username, rm_all, file, folder, config):
             f"Are you sure you want to delete all files within project '{project}'?"
         ):
             LOG.info("Probably for the best. Exiting.")
-            os._exit(0)
+            sys.exit(0)
 
-    with dds_cli.data_remover.DataRemover(
-        project=project,
-        username=username,
-        config=dds_info["CONFIG"] if config is None else config,
-    ) as remover:
+    try:
+        with dds_cli.data_remover.DataRemover(
+            project=project,
+            username=username,
+            config=dds_info["CONFIG"] if config is None else config,
+        ) as remover:
 
-        if rm_all:
-            remover.remove_all()
+            if rm_all:
+                remover.remove_all()
 
-        elif file:
-            remover.remove_file(files=file)
+            elif file:
+                remover.remove_file(files=file)
 
-        elif folder:
-            remover.remove_folder(folder=folder)
+            elif folder:
+                remover.remove_folder(folder=folder)
+    except (dds_cli.exceptions.AuthenticationError) as e:
+        LOG.error(e)
+        sys.exit(1)
 
 
 ####################################################################################################

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -97,7 +97,10 @@ def dds_main(ctx, verbose, log_file):
         if not any(x in sys.argv for x in ["--config", "-c", "--username", "-u"]):
             config_file = pathlib.Path().home() / pathlib.Path(".dds-cli.json")
             if not config_file.is_file():
-                raise exc.ConfigFileNotFoundError(config_file)
+                LOG.error(
+                    f"Username omitted and config file not specified nor found at default path: {config_file}"
+                )
+                sys.exit(1)
 
         # Create context object
         ctx.obj = {
@@ -480,7 +483,11 @@ def rm(dds_info, proj_arg, project, username, rm_all, file, folder, config):
 
             elif folder:
                 remover.remove_folder(folder=folder)
-    except (dds_cli.exceptions.AuthenticationError, dds_cli.exceptions.APIError) as e:
+    except (
+        dds_cli.exceptions.AuthenticationError,
+        dds_cli.exceptions.APIError,
+        dds_cli.exceptions.DDSCLIException,
+    ) as e:
         LOG.error(e)
         sys.exit(1)
 
@@ -745,6 +752,10 @@ def create(dds_info, config, username, title, description, principal_investigato
                 LOG.info(
                     f"Project created with id: {project_id}",
                 )
-    except (dds_cli.exceptions.APIError, dds_cli.exceptions.AuthenticationError) as e:
+    except (
+        dds_cli.exceptions.APIError,
+        dds_cli.exceptions.AuthenticationError,
+        dds_cli.exceptions.DDSCLIException,
+    ) as e:
         LOG.error(e)
         sys.exit(1)

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -425,7 +425,7 @@ def rm(dds_info, proj_arg, project, username, rm_all, file, folder, config):
 
             elif folder:
                 remover.remove_folder(folder=folder)
-    except (dds_cli.exceptions.AuthenticationError) as e:
+    except (dds_cli.exceptions.AuthenticationError, dds_cli.exceptions.APIError) as e:
         LOG.error(e)
         sys.exit(1)
 

--- a/dds_cli/cli_decorators.py
+++ b/dds_cli/cli_decorators.py
@@ -191,43 +191,35 @@ def removal_spinner(func):
 
             # Determine spinner text
             if func.__name__ == "remove_all":
-                description = f"Removing all files in project {self.project}..."
+                description = f"Removing all files in project {self.project}"
             elif func.__name__ == "remove_file":
-                description = "Removing file(s)..."
+                description = "Removing file(s)"
             elif func.__name__ == "remove_folder":
-                description = "Removing folder(s)..."
+                description = "Removing folder(s)"
 
             # Add progress task
-            task = progress.add_task(description=description)
+            task = progress.add_task(description=f"{description}...")
 
-            # Execute function
-            message = func(self, *args, **kwargs)
+            # Execute function, exceptions are caught in __main__.py
+            func(self, *args, **kwargs)
 
             # Remove progress task
             progress.remove_task(task)
 
         # Printout removal response
-        if message is None:
-            rm_type = "File" if func.__name__ == "remove_file" else "Folder"
 
-            message = f"{rm_type}(s) successfully removed."
+        # reuse the description but don't want the capital letter in the middle of the sentence.
+        description_lc = description[0].lower() + description[1:]
+        if self.failed_table is not None:
+            table_len = self.failed_table.renderable.row_count
 
-        # Compute size of table
-        if isinstance(message, rich.padding.Padding) and isinstance(
-            message.renderable, rich.table.Table
-        ):
-            table_len = message.renderable.row_count + message.top + message.bottom
-        elif isinstance(message, rich.table.Table):
-            table_len = message.row_count
+            if table_len + 5 > dds_cli.utils.console.height:
+                with dds_cli.utils.console.pager():
+                    dds_cli.utils.console.print(self.failed_table)
+            else:
+                dds_cli.utils.console.print(self.failed_table)
+            LOG.warning(f"Finished {description_lc} with errors, see table above")
         else:
-            # The message is probably not a table and should
-            # therefore be printed directly
-            table_len = 0
-
-        if table_len + 5 > dds_cli.utils.console.height:
-            with dds_cli.utils.console.pager():
-                dds_cli.utils.console.print(message)
-        else:
-            dds_cli.utils.console.print(message)
+            LOG.info(f"Successfully finished {description_lc}")
 
     return create_and_remove_task

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -154,7 +154,7 @@ class DataLister(base.DDSBaseClass):
         except requests.exceptions.RequestException as err:
             raise exceptions.ApiRequestError(message=str(err))
 
-        # Check resposne
+        # Check response
         if not response.ok:
             raise exceptions.APIError(f"Failed to get list of projects: {response.text}")
 

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -177,8 +177,6 @@ class DataLister(base.DDSBaseClass):
         # Column format
         column_formatting = self.format_columns(total_size=total_size, usage_info=usage_info)
 
-        LOG.info(column_formatting)
-
         # Create table
         table = Table(
             title="Your Projects",

--- a/dds_cli/data_remover.py
+++ b/dds_cli/data_remover.py
@@ -56,7 +56,7 @@ class DataRemover(base.DDSBaseClass):
 
         # Check that enough info
         if not all(x in resp_json for x in ["not_exists", "not_removed"]):
-            raise dds_cli.exception.ApiResponseError(
+            raise dds_cli.exception.APIError(
                 f"Malformatted response detected when attempting remove action on {self.project}."
             )
 
@@ -115,9 +115,7 @@ class DataRemover(base.DDSBaseClass):
             raise SystemExit from err
 
         if not response.ok:
-            raise dds_cli.exceptions.ApiResponseError(
-                f"Failed to delete files in project: {response.text}"
-            )
+            raise dds_cli.exceptions.APIError(f"Failed to delete files in project: {response.text}")
 
         # Print out response - deleted or not?
         try:
@@ -126,7 +124,7 @@ class DataRemover(base.DDSBaseClass):
             raise SystemExit from err
 
         if "removed" not in resp_json:
-            raise dds_cli.exception.ApiResponseError(
+            raise dds_cli.exception.APIError(
                 f"Malformatted response detected when attempting to remove all files from {self.project}."
             )
 
@@ -145,7 +143,7 @@ class DataRemover(base.DDSBaseClass):
             raise SystemExit from err
 
         if not response.ok:
-            raise dds_cli.exceptions.ApiResponseError(
+            raise dds_cli.exceptions.APIError(
                 f"Failed to delete file(s) '{files}' in project {self.project}: {response.text}"
             )
 
@@ -172,7 +170,7 @@ class DataRemover(base.DDSBaseClass):
             raise SystemExit from err
 
         if not response.ok:
-            raise dds_cli.exceptions.ApiResponseError(
+            raise dds_cli.exceptions.APIError(
                 f"Failed to delete folder(s) '{folder}' "
                 f"in project {self.project}: {response.text}"
             )

--- a/dds_cli/data_remover.py
+++ b/dds_cli/data_remover.py
@@ -51,7 +51,7 @@ class DataRemover(base.DDSBaseClass):
                 attempted_method=method, message="DataRemover attempting unauthorized method"
             )
 
-    def __response_delete(self, resp_json, level="File"):
+    def __create_failed_table(self, resp_json, level="File"):
         """Output a response after deletion."""
 
         # Check that enough info
@@ -155,7 +155,7 @@ class DataRemover(base.DDSBaseClass):
         except simplejson.JSONDecodeError as err:
             raise SystemExit from err
 
-        self.__response_delete(resp_json=resp_json)
+        self.__create_failed_table(resp_json=resp_json)
 
     @removal_spinner
     def remove_folder(self, folder):
@@ -183,4 +183,4 @@ class DataRemover(base.DDSBaseClass):
         except simplejson.JSONDecodeError as err:
             raise SystemExit from err
 
-        self.__response_delete(resp_json=resp_json, level="Folder")
+        self.__create_failed_table(resp_json=resp_json, level="Folder")

--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -31,26 +31,6 @@ class ConfigFileNotFoundError(click.ClickException):
         click.echo(self)
 
 
-class ConfigFileExtractionError(Exception):
-    """Could not extract any info from the config file."""
-
-    def __init__(
-        self,
-        filepath,
-        message: str = "Could not extract info from config file",
-        caught_exception=None,
-    ):
-        self.filepath = filepath
-        self.message = message
-        super().__init__(message)
-
-        if caught_exception:
-            LOG.exception(caught_exception.args[0] + "\n" + self.__str__())
-
-    def __str__(self):
-        return f"{self.message}: {self.filepath}"
-
-
 class InvalidMethodError(Exception):
     """Valid methods are only ls, put, get, rm. Anything else should raise errors."""
 
@@ -126,4 +106,3 @@ class NoDataError(Exception):
 
 class APIError(Exception):
     """Error connecting to the dds web server"""
-

--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -126,3 +126,4 @@ class NoDataError(Exception):
 
 class APIError(Exception):
     """Error connecting to the dds web server"""
+

--- a/dds_cli/file_handler.py
+++ b/dds_cli/file_handler.py
@@ -75,8 +75,8 @@ class FileHandler:
             with configpath.open(mode="r") as cfp:
                 contents = json.load(cfp)
         except json.decoder.JSONDecodeError as err:
-            raise dds_cli.exceptions.ConfigFileExtractionError(
-                filepath=configpath, caught_exception=err
+            raise dds_cli.exceptions.DDSCLIException(
+                f"Could not extract info from config file: {configpath}, please make sure it is in valid json format."
             )
         finally:
             os.umask(original_umask)

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -1,4 +1,3 @@
 import rich.console
 
 console = rich.console.Console(stderr=True)
-# console = rich.console.Console()

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -30,7 +30,7 @@ def test_filehandler_extract_config_empty():
     """Empty config should raise exception"""
 
     configfile = CONFIG_PATH / pathlib.Path("empty_config.json")
-    with pytest.raises(exceptions.ConfigFileExtractionError):
+    with pytest.raises(exceptions.DDSCLIException):
         _ = file_handler.FileHandler.extract_config(configfile=configfile)
 
 


### PR DESCRIPTION
A bit of a mixture in here, just things I found could use some improvement along with removing file and line origin of log statements by default. 

 - Improved but simplified handling of errors related to config finding
 - Show line numbers for log entries only if `--verbose` is used
 - Raise exceptions instead of returning messages for `dds rm` errors
 - Made the failure report table an attribute instead of a message
 - Replaced a bunch of `os._exit` with `sys.exit`