### PR TITLE
Username not required

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -470,7 +470,7 @@ def rm(_, proj_arg, project, username, rm_all, file, folder):
     "-p",
     required=True,
     type=str,
-    help="Project ID to which you're uploading data.",
+    help="Project ID from which you're downloading data.",
 )
 @click.option(
     "--get-all",

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -156,7 +156,7 @@ def add_user(_, username, email, role, project):
 @click.option(
     "--project",
     "-p",
-    required=False,
+    required=True,
     type=str,
     help="Project ID to which you're uploading data",
 )
@@ -387,7 +387,7 @@ def ls(_, project, folder, projects, size, username, usage, sort, tree, users):
 
 @dds_main.command()
 @click.argument("proj_arg", required=False)
-@click.option("--project", "-p", required=False, type=str, help="Project ID.")
+@click.option("--project", "-p", required=True, type=str, help="Project ID.")
 @click.option(
     "--username", "-u", required=False, type=str, help="Your Data Delivery System username."
 )
@@ -468,7 +468,7 @@ def rm(_, proj_arg, project, username, rm_all, file, folder):
 @click.option(
     "--project",
     "-p",
-    required=False,
+    required=True,
     type=str,
     help="Project ID to which you're uploading data.",
 )
@@ -748,9 +748,9 @@ def create(
 @click.option(
     "--username",
     "-u",
-    required=True,
+    required=False,
     type=str,
-    help="Your Data Delivery System username.",
+    help="Your Data Delivery System username. Required unless the `--check` flag is used.",
 )
 @click.option(
     "--check",
@@ -761,7 +761,7 @@ def create(
 )
 @click.pass_obj
 def session(_, username, check):
-    """Renew the access token stored in the '.dds_cli_token'. Run this command before
+    """Renew the access token stored in the '.dds_cli_token' file. Run this command before
     running the cli in a non interactive fashion as this enables the longest possible session time
     before a password needs to be entered again.
     """

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -98,7 +98,7 @@ def dds_main(_, verbose, log_file):
 @click.option(
     "--username",
     "-u",
-    required=True,
+    required=False,
     type=str,
     help="Your Data Delivery System username.",
 )
@@ -144,7 +144,7 @@ def add_user(_, username, email, role, project):
 @click.option(
     "--username",
     "-u",
-    required=True,
+    required=False,
     type=str,
     help="Your Data Delivery System username",
 )
@@ -245,7 +245,7 @@ def put(
 @click.option("--projects", "-lp", is_flag=True, help="List all project connected to your account.")
 @click.option("--size", "-s", is_flag=True, default=False, help="Show size of project contents.")
 @click.option(
-    "--username", "-u", required=True, type=str, help="Your Data Delivery System username."
+    "--username", "-u", required=False, type=str, help="Your Data Delivery System username."
 )
 @click.option(
     "--usage",
@@ -384,7 +384,7 @@ def ls(_, project, folder, projects, size, username, usage, sort, tree, users):
 @click.argument("proj_arg", required=False)
 @click.option("--project", "-p", required=False, type=str, help="Project ID.")
 @click.option(
-    "--username", "-u", required=True, type=str, help="Your Data Delivery System username."
+    "--username", "-u", required=False, type=str, help="Your Data Delivery System username."
 )
 @click.option("--rm-all", "-a", is_flag=True, default=False, help="Remove all project contents.")
 @click.option(
@@ -456,7 +456,7 @@ def rm(_, proj_arg, project, username, rm_all, file, folder):
 @click.option(
     "--username",
     "-u",
-    required=True,
+    required=False,
     type=str,
     help="Your Data Delivery System username.",
 )
@@ -637,7 +637,7 @@ def get(
 @click.option(
     "--username",
     "-u",
-    required=True,
+    required=False,
     type=str,
     help="Your Data Delivery System username.",
 )

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -57,8 +57,11 @@ class DDSBaseClass:
         force_renew_token: bool = False,
     ):
         """Initialize Base class for authenticating the user and preparing for DDS action."""
+        self.username = username
+        self.project = project
         self.method_check = method_check
         self.method = method
+
         if self.method_check:
             # Get attempted operation e.g. put/ls/rm/get
             if self.method not in DDS_METHODS:
@@ -80,12 +83,6 @@ class DDSBaseClass:
 
         # Keyboardinterrupt
         self.stop_doing = False
-
-        # Verify that user entered enough info
-        username, self.project = self.__verify_input(
-            username=username,
-            project=project,
-        )
 
         # Authenticate the user and get the token
         if authenticate:
@@ -118,27 +115,6 @@ class DDSBaseClass:
         return True
 
     # Private methods ############################### Private methods #
-    def __verify_input(
-        self,
-        username,
-        project=None,
-    ) -> tuple:
-        """Verify that the users input is valid and fully specified."""
-        LOG.debug("Verifying the user input...")
-
-        # Username and project info is minimum required info
-        if self.method in ["put", "get"] and not project:
-            dds_cli.utils.console.print(
-                "\n:warning: Data Delivery System project information is missing. :warning:\n"
-            )
-            os._exit(1)
-
-        if not username:
-            raise exceptions.MissingCredentialsException(missing="username")
-
-        LOG.debug("User input verified.")
-
-        return username, project
 
     def __get_project_keys(self):
         """Get public and private project keys depending on method."""

--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -51,7 +51,6 @@ class MissingCredentialsException(AuthenticationError):
     def __init__(self, missing, message="Data Delivery System options are missing"):
         """Reformat error message."""
         self.message = f"{message}: [red]{missing}[/red]"
-        LOG.error(self.message)
         super().__init__(self.message)
 
 
@@ -60,7 +59,6 @@ class TokenNotFoundError(AuthenticationError):
 
     def __init__(self, message, sign=":warning:"):
         """Reformat error message."""
-        LOG.error(message)
         super().__init__(message=message, sign=sign)
 
 

--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -45,15 +45,6 @@ class AuthenticationError(click.ClickException):
         return f"{self.sign} {self.message} {self.sign}"
 
 
-class MissingCredentialsException(AuthenticationError):
-    """All user options not specified."""
-
-    def __init__(self, missing, message="Data Delivery System options are missing"):
-        """Reformat error message."""
-        self.message = f"{message}: [red]{missing}[/red]"
-        super().__init__(self.message)
-
-
 class TokenNotFoundError(AuthenticationError):
     """No token retrieved from REST API or from File."""
 

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -73,14 +73,15 @@ class User:
     def __authenticate_user(self):
         """Authenticates the username and password via a call to the API."""
 
+        if self.username is None:
+            raise exceptions.MissingCredentialsException(missing="username")
+
         LOG.info(f"Authenticating the user: {self.username} on the api")
 
         password = getpass.getpass(prompt="DDS Password: ")
-        # Username and password required for user authentication
-        if None in [self.username, password]:
-            raise exceptions.MissingCredentialsException(
-                missing="username" if not self.username else "password",
-            )
+
+        if self.password is None:
+            raise exceptions.MissingCredentialsException(missing="password")
 
         # Project passed in to add it to the token. Can be None.
         try:


### PR DESCRIPTION
- Made username argument not required as this is only required when the session token needs to be renewed. 
- Instead made project argument required where it actually is, which removed the need for the __verify_input method.
- Got rid of the `MissingCredentialsException` class as the `AuthenticationError` is sufficient.