### PR TITLE
Issue703: Introduce dds user command group

### DIFF
--- a/dds_cli/__init__.py
+++ b/dds_cli/__init__.py
@@ -65,6 +65,7 @@ class DDSEndpoint:
     # User management
     USER_ADD = BASE_ENDPOINT + "/user/add"
     USER_DELETE = BASE_ENDPOINT + "/user/delete"
+    USER_DELETE_SELF = BASE_ENDPOINT + "/user/delete_self"
 
     # Authentication - user and project
     ENCRYPTED_TOKEN = BASE_ENDPOINT + "/user/encrypted_token"

--- a/dds_cli/__init__.py
+++ b/dds_cli/__init__.py
@@ -33,7 +33,7 @@ __all__ = [
 ###############################################################################
 
 # Keep track of all allowed methods
-DDS_METHODS = ["put", "get", "ls", "rm", "create", "add"]
+DDS_METHODS = ["put", "get", "ls", "rm", "create", "add", "delete"]
 
 # Methods to which a directory created by DDS
 DDS_DIR_REQUIRED_METHODS = ["put", "get"]
@@ -62,8 +62,9 @@ class DDSEndpoint:
         BASE_ENDPOINT_LOCAL if os.getenv("DDS_CLI_ENV") == "development" else BASE_ENDPOINT_REMOTE
     )
 
-    # User creation
+    # User management
     USER_ADD = BASE_ENDPOINT + "/user/add"
+    USER_DELETE = BASE_ENDPOINT + "/user/delete"
 
     # Authentication - user and project
     ENCRYPTED_TOKEN = BASE_ENDPOINT + "/user/encrypted_token"

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -1044,7 +1044,7 @@ def add(click_ctx, username, email, role, project):
 
 
 ## Delete users from the system
-@user.command(no_args_is_help=True)
+@user.command(name="delete", no_args_is_help=True)
 @click.argument(
     "email",
     nargs=1,
@@ -1059,7 +1059,7 @@ def add(click_ctx, username, email, role, project):
     help="Decommission your own user account",
 )
 @click.pass_obj
-def delete(click_ctx, email, self):
+def delete_users(click_ctx, email, self):
     """
     Delete user accounts from the Data Delivery System.
 

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -1014,8 +1014,15 @@ def user(click_ctx):
     help="Existing Project you want the user to be associated to.",
 )
 @click.pass_obj
-def invite(click_ctx, username, email, role, project):
-    """Add a user to DDS, sending an invitation email to that person."""
+def add(click_ctx, username, email, role, project):
+    """
+    Add a user to the DDS system or hosted projects.
+
+    Specify an user's email and role to associate it with projects.
+    If the user doesn't exist in the system yet, an invitation email
+    will be sent automatically to that person.
+
+    """
     try:
         with dds_cli.account_manager.AccountManager(
             username=username, no_prompt=click_ctx.get("NO_PROMPT", False)
@@ -1073,7 +1080,6 @@ def delete(click_ctx, email, self):
     try:
         with dds_cli.account_manager.AccountManager(
             username=None,
-            authenticate=True,
             method="delete",
             no_prompt=click_ctx.get("NO_PROMPT", False),
         ) as manager:

--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -80,11 +80,10 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         LOG.info(response_json.get("message", "User successfully added."))
 
-    def delete_user(self, email, ownaccount):
+    def delete_user(self, email):
         """Delete users from the system"""
-
         # Perform request to API
-        json = {"email": email, "ownaccount": ownaccount}
+        json = {"email": email}
 
         try:
             response = requests.post(
@@ -95,6 +94,8 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
             # Get response
             response_json = response.json()
+            message = response_json["message"]
+
         except requests.exceptions.RequestException as err:
             raise dds_cli.exceptions.ApiRequestError(message=str(err))
         except simplejson.JSONDecodeError as err:
@@ -102,12 +103,38 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         # Format response message
         if not response.ok:
-            message = response_json["message"]
-
             if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
                 raise dds_cli.exceptions.ApiResponseError(message)
             else:
                 raise dds_cli.exceptions.DDSCLIException(message)
-
         else:
-            LOG.info(response_json["message"])
+            LOG.info(message)
+
+    def delete_own_account(self):
+        """Delete users from the system"""
+        # Perform request to API
+
+        try:
+            response = requests.post(
+                dds_cli.DDSEndpoint.USER_DELETE_SELF,
+                headers=self.token,
+                json=None,
+            )
+
+            # Get response
+            response_json = response.json()
+            message = response_json["message"]
+
+        except requests.exceptions.RequestException as err:
+            raise dds_cli.exceptions.ApiRequestError(message=str(err))
+        except simplejson.JSONDecodeError as err:
+            raise dds_cli.exceptions.ApiResponseError(message=str(err))
+
+        # Format response message
+        if not response.ok:
+            if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
+                raise dds_cli.exceptions.ApiResponseError(message)
+            else:
+                raise dds_cli.exceptions.DDSCLIException(message)
+        else:
+            LOG.info(message)

--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -95,7 +95,6 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
             # Get response
             response_json = response.json()
-            LOG.info(response_json)
         except requests.exceptions.RequestException as err:
             raise dds_cli.exceptions.ApiRequestError(message=str(err))
         except simplejson.JSONDecodeError as err:
@@ -103,19 +102,12 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         # Format response message
         if not response.ok:
-            message = response_json.get("message")
+            message = response_json["message"]
+
             if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
-                raise dds_cli.exceptions.ApiResponseError(message=f"{message}")
-            elif response.status_code == http.HTTPStatus.FORBIDDEN:
-                raise dds_cli.exceptions.DDSCLIException(
-                    "You need to be an administrator to delete this user!"
-                )
-            elif response.status_code == http.HTTPStatus.BAD_REQUEST:
-                # if message.get("email"):
-                #    raise dds_cli.exceptions.DDSCLIException(message.get("email"))
-                # elif message.get("projectowner"):
-                #    raise dds_cli.exceptions.DDSCLIException(message.get("projectowner"))
-                # else:
-                raise dds_cli.exceptions.DDSCLIException(message)
+                raise dds_cli.exceptions.ApiResponseError(message)
             else:
                 raise dds_cli.exceptions.DDSCLIException(message)
+
+        else:
+            LOG.info(response_json["message"])

--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -15,8 +15,9 @@ import simplejson
 
 # Own modules
 import dds_cli
-import dds_cli.exceptions
+import dds_cli.auth
 import dds_cli.base
+import dds_cli.exceptions
 
 ####################################################################################################
 # START LOGGING CONFIG ###################################################### START LOGGING CONFIG #
@@ -79,10 +80,11 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         LOG.info(response_json.get("message", "User successfully added."))
 
-    def delete_user(self, accounts):
+    def delete_user(self, email, ownaccount):
         """Delete users from the system"""
+
         # Perform request to API
-        json = {"accounts": accounts, "username": self.username}
+        json = {"email": email, "username": self.username, "ownaccount": ownaccount}
 
         try:
             response = requests.post(
@@ -101,7 +103,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         # Format response message
         if not response.ok:
-            message = "Could not delete user(s)"
+            message = "Could not delete usee"
             if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
                 raise dds_cli.exceptions.ApiResponseError(message=f"{message}: {response.reason}")
 
@@ -109,4 +111,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
                 message=f"{message}: {response_json.get('message', 'Unexpected error!')}"
             )
 
-        LOG.info(response_json.get("message", f"User {accounts} successfully deleted."))
+        if ownaccount:
+            LOG.info(response_json.get("message", f"An email asking for confirmation was sent to your inbox."))
+        else: 
+            LOG.info(response_json.get("message", f"User {email} successfully deleted."))

--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -85,7 +85,6 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         # Perform request to API
         json = {"email": email, "ownaccount": ownaccount}
-        LOG.info(json)
 
         try:
             response = requests.post(
@@ -96,7 +95,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
             # Get response
             response_json = response.json()
-            LOG.debug(response_json)
+            LOG.info(response_json)
         except requests.exceptions.RequestException as err:
             raise dds_cli.exceptions.ApiRequestError(message=str(err))
         except simplejson.JSONDecodeError as err:
@@ -104,19 +103,19 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         # Format response message
         if not response.ok:
-            message = "Could not delete user"
+            message = response_json.get("message")
             if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
-                raise dds_cli.exceptions.ApiResponseError(message=f"{message}: {response.reason}")
-
-            raise dds_cli.exceptions.DDSCLIException(
-                message=f"{message}: {response_json.get('message', 'Unexpected error!')}"
-            )
-
-        if ownaccount:
-            LOG.info(
-                response_json.get(
-                    "message", f"An email asking for confirmation was sent to your inbox."
+                raise dds_cli.exceptions.ApiResponseError(message=f"{message}")
+            elif response.status_code == http.HTTPStatus.FORBIDDEN:
+                raise dds_cli.exceptions.DDSCLIException(
+                    "You need to be an administrator to delete this user!"
                 )
-            )
-        else:
-            LOG.info(response_json.get("message", f"User {email} successfully deleted."))
+            elif response.status_code == http.HTTPStatus.BAD_REQUEST:
+                # if message.get("email"):
+                #    raise dds_cli.exceptions.DDSCLIException(message.get("email"))
+                # elif message.get("projectowner"):
+                #    raise dds_cli.exceptions.DDSCLIException(message.get("projectowner"))
+                # else:
+                raise dds_cli.exceptions.DDSCLIException(message)
+            else:
+                raise dds_cli.exceptions.DDSCLIException(message)

--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -48,7 +48,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
             raise dds_cli.exceptions.AuthenticationError(f"Unauthorized method: '{self.method}'")
 
     def add_user(self, email, role, project):
-        """Invite user."""
+        """Invite new user or associate existing users with projects."""
         # Perform request to API
         json = {"email": email, "role": role}
         if project:
@@ -84,7 +84,8 @@ class AccountManager(dds_cli.base.DDSBaseClass):
         """Delete users from the system"""
 
         # Perform request to API
-        json = {"email": email, "username": self.username, "ownaccount": ownaccount}
+        json = {"email": email, "ownaccount": ownaccount}
+        LOG.info(json)
 
         try:
             response = requests.post(
@@ -103,7 +104,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
 
         # Format response message
         if not response.ok:
-            message = "Could not delete usee"
+            message = "Could not delete user"
             if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
                 raise dds_cli.exceptions.ApiResponseError(message=f"{message}: {response.reason}")
 
@@ -112,6 +113,10 @@ class AccountManager(dds_cli.base.DDSBaseClass):
             )
 
         if ownaccount:
-            LOG.info(response_json.get("message", f"An email asking for confirmation was sent to your inbox."))
-        else: 
+            LOG.info(
+                response_json.get(
+                    "message", f"An email asking for confirmation was sent to your inbox."
+                )
+            )
+        else:
             LOG.info(response_json.get("message", f"User {email} successfully deleted."))

--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -86,7 +86,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
         json = {"email": email}
 
         try:
-            response = requests.post(
+            response = requests.delete(
                 dds_cli.DDSEndpoint.USER_DELETE,
                 headers=self.token,
                 json=json,
@@ -115,7 +115,7 @@ class AccountManager(dds_cli.base.DDSBaseClass):
         # Perform request to API
 
         try:
-            response = requests.post(
+            response = requests.delete(
                 dds_cli.DDSEndpoint.USER_DELETE_SELF,
                 headers=self.token,
                 json=None,

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -92,7 +92,7 @@ class User:
         if self.username is None:
             self.username = rich.prompt.Prompt.ask("DDS username")
 
-        password = getpass.getpass(prompt="DDS Password: ")
+        password = getpass.getpass(prompt="DDS password: ")
 
         if password == "":
             raise exceptions.AuthenticationError(

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -1,8 +1,15 @@
+<<<<<<< HEAD
 """DDS CLI utils module."""
 
 import numbers
 import rich.console
 import simplejson
+=======
+import click
+import rich.console
+import numbers
+import re
+>>>>>>> 411efc1 (Add validator function for emails (only Regex, not functional))
 
 console = rich.console.Console()
 stderr_console = rich.console.Console(stderr=True)
@@ -105,16 +112,16 @@ def format_api_response(response, key, magnitude=None, iec_standard=False):
                     spacerA,
                     prefixlist[magnitude] + spacerB + unit,
                 )
+            else:  # if values are anyway prefixed individually, then strip trailing 0 for readability
+                return "{}{}{}".format(
+                    "{:.2f}".format(response).rstrip("0").rstrip("."),
+                    spacerA,
+                    prefixlist[mag] + spacerB + unit,
+                )
+        else:
+            return f"0 {unit}"
+    else:
+        # Since table.add.row() expects a string, try to return whatever is not yet a string but also not numeric as string
+        return str(response)
 
-            # if values are anyway prefixed individually, then strip trailing 0 for readability
-            return "{}{}{}".format(
-                "{:.2f}".format(response).rstrip("0").rstrip("."),
-                spacerA,
-                prefixlist[mag] + spacerB + unit,
-            )
 
-        return f"0 {unit}"
-
-    # Since table.add.row() expects a string,
-    # try to return whatever is not yet a string but also not numeric as string
-    return str(response)

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -1,15 +1,14 @@
-<<<<<<< HEAD
 """DDS CLI utils module."""
 
 import numbers
 import rich.console
 import simplejson
-=======
+
 import click
 import rich.console
 import numbers
-import re
->>>>>>> 411efc1 (Add validator function for emails (only Regex, not functional))
+import rich.console
+import numbers
 
 console = rich.console.Console()
 stderr_console = rich.console.Console(stderr=True)
@@ -123,5 +122,3 @@ def format_api_response(response, key, magnitude=None, iec_standard=False):
     else:
         # Since table.add.row() expects a string, try to return whatever is not yet a string but also not numeric as string
         return str(response)
-
-

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -4,12 +4,6 @@ import numbers
 import rich.console
 import simplejson
 
-import click
-import rich.console
-import numbers
-import rich.console
-import numbers
-
 console = rich.console.Console()
 stderr_console = rich.console.Console(stderr=True)
 

--- a/tests/test_add_user.py
+++ b/tests/test_add_user.py
@@ -19,7 +19,8 @@ def runner_with_project(runner):
     def _run():
         return runner(
             [
-                "user add",
+                "user",
+                "add",
                 "-u",
                 "unituser",
                 "-r",
@@ -38,7 +39,7 @@ def runner_no_project(runner):
     """Run dds add-user without a project specified."""
 
     def _run():
-        return runner(["user add", "-u", "unituser", "-r", ADD_JSON["role"], ADD_JSON["email"]])
+        return runner(["user", "add", "-u", "unituser", "-r", ADD_JSON["role"], ADD_JSON["email"]])
 
     yield _run
 

--- a/tests/test_add_user.py
+++ b/tests/test_add_user.py
@@ -19,15 +19,14 @@ def runner_with_project(runner):
     def _run():
         return runner(
             [
-                "add-user",
+                "user add",
                 "-u",
                 "unituser",
-                "-e",
-                ADD_JSON["email"],
                 "-r",
                 ADD_JSON["role"],
                 "-p",
                 ADD_JSON_PROJECT["project"],
+                ADD_JSON["email"],
             ]
         )
 
@@ -39,9 +38,7 @@ def runner_no_project(runner):
     """Run dds add-user without a project specified."""
 
     def _run():
-        return runner(
-            ["add-user", "-u", "unituser", "-e", ADD_JSON["email"], "-r", ADD_JSON["role"]]
-        )
+        return runner(["user add", "-u", "unituser", "-r", ADD_JSON["role"], ADD_JSON["email"]])
 
     yield _run
 


### PR DESCRIPTION
This PR comprises the necessary changes to the CLI to address [issue 703](https://github.com/ScilifelabDataCentre/dds_web/issues/703) from the web: 

- Newly introduced the feature to delete user accounts in the CLI.
- To delete the own account, one would need to enter `dds user delete --self`
-  To delete any other account (given sufficient administrative privileges), one would need to specify `dds user delete EMAIL`
- The former `dds add-user`  command is now `dds user add` and its former option `--email` is now its argument.
- Created an `utils.email_validator` function that will employ a simple Regex to check if a valid email address was entered before dispatching the API call since a failed marshmallow validation doesn't seem to be properly handled in the CLI so far.