### PR TITLE
Logging vs progressbars

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -77,7 +77,7 @@ def dds_main(click_ctx, verbose, log_file, no_prompt):
         # Set up logs to the console
         LOG.addHandler(
             rich.logging.RichHandler(
-                level=logging.DEBUG if verbose else logging.WARNING,
+                level=logging.DEBUG if verbose else logging.INFO,
                 console=dds_cli.utils.stderr_console,
                 show_time=False,
                 markup=True,
@@ -625,7 +625,7 @@ def get(
                 " • ",
                 "[progress.percentage]{task.percentage:>3.1f}%",
                 refresh_per_second=2,
-                console=dds_cli.utils.console,
+                console=dds_cli.utils.stderr_console,
             ) as progress:
 
                 # Keep track of futures
@@ -641,7 +641,7 @@ def get(
 
                     # Schedule the first num_threads futures for upload
                     for file in itertools.islice(iterator, num_threads):
-                        LOG.info(f"Starting: {file}")
+                        LOG.debug(f"Starting: {file}")
                         # Execute download
                         download_threads[
                             texec.submit(getter.download_and_verify, file=file, progress=progress)
@@ -657,14 +657,14 @@ def get(
 
                         for dfut in ddone:
                             downloaded_file = download_threads.pop(dfut)
-                            LOG.info(
+                            LOG.debug(
                                 f"Future done: {downloaded_file}",
                             )
 
                             # Get result
                             try:
                                 file_downloaded = dfut.result()
-                                LOG.info(
+                                LOG.debug(
                                     f"Download of {downloaded_file} successful: {file_downloaded}"
                                 )
                             except concurrent.futures.BrokenExecutor as err:
@@ -678,7 +678,7 @@ def get(
 
                         # Schedule the next set of futures for download
                         for next_file in itertools.islice(iterator, new_tasks):
-                            LOG.info(f"Starting: {next_file}")
+                            LOG.debug(f"Starting: {next_file}")
                             # Execute download
                             download_threads[
                                 texec.submit(

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -186,13 +186,13 @@ class DDSBaseClass:
                 f"Errors occurred during {'upload' if self.method == 'put' else 'download'}"
             )
 
-            utils.console.print(
+            utils.stderr_console.print(
                 f"{intro_error_message}. See {self.failed_delivery_log} for more information."
             )
 
         else:
             # Printout if no cancelled/failed files
-            LOG.debug(f"\n{'Upload' if self.method == 'put' else 'Download'} completed!\n")
+            LOG.info(f"\n{'Upload' if self.method == 'put' else 'Download'} completed!\n")
 
         if self.method == "get" and len(self.filehandler.data) > len(any_failed):
             LOG.info(f"Any downloaded files are located: {self.filehandler.local_destination}.")

--- a/dds_cli/cli_decorators.py
+++ b/dds_cli/cli_decorators.py
@@ -52,7 +52,7 @@ def verify_proceed(func):
 
         # Mark as started
         self.status[file]["started"] = True
-        LOG.info(f"File {file} started {func.__name__}")
+        LOG.debug(f"File {file} started {func.__name__}")
 
         # Run function
         ok_to_proceed, message = func(self, file=file, *args, **kwargs)
@@ -135,7 +135,7 @@ def subpath_required(func):
             except OSError as err:
                 return False, str(err)
 
-            LOG.info(f"New directory created: {full_subpath}")
+            LOG.debug(f"New directory created: {full_subpath}")
 
         return func(self, file=file, *args, **kwargs)
 
@@ -153,7 +153,7 @@ def removal_spinner(func):
         with Progress(
             "[bold]{task.description}",
             SpinnerColumn(spinner_name="dots12", style="white"),
-            console=dds_cli.utils.console,
+            console=dds_cli.utils.stderr_console,
         ) as progress:
 
             # Determine spinner text

--- a/dds_cli/cli_decorators.py
+++ b/dds_cli/cli_decorators.py
@@ -66,7 +66,7 @@ def verify_proceed(func):
 
             if self.break_on_fail:
                 message = f"'--break-on-fail'. File causing failure: '{file}'. "
-                LOG.info(message)
+                LOG.warning(message)
 
                 _ = [
                     self.status[x].update({"cancel": True, "message": message})

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -79,7 +79,7 @@ class DataGetter(base.DDSBaseClass):
         with Progress(
             "[bold]{task.description}",
             SpinnerColumn(spinner_name="dots12", style="white"),
-            console=dds_cli.utils.console,
+            console=dds_cli.utils.stderr_console,
         ) as progress:
             wait_task = progress.add_task("Collecting and preparing data", step="prepare")
             self.filehandler = fhr.RemoteFileHandler(
@@ -135,7 +135,7 @@ class DataGetter(base.DDSBaseClass):
             db_updated, message = self.update_db(file=file)
             LOG.debug(f"Database updated: {db_updated}")
 
-            LOG.info(f"Beginning decryption of file {file}...")
+            LOG.debug(f"Beginning decryption of file {file}...")
             file_saved = False
             with fe.Decryptor(
                 project_keys=self.keys,

--- a/dds_cli/data_putter.py
+++ b/dds_cli/data_putter.py
@@ -91,7 +91,7 @@ def put(
 
                 # Schedule the first num_threads futures for upload
                 for file in itertools.islice(iterator, num_threads):
-                    LOG.info(f"Starting: {file}")
+                    LOG.debug(f"Starting: {file}")
                     upload_threads[
                         texec.submit(
                             putter.protect_and_upload,
@@ -133,7 +133,7 @@ def put(
 
                         # Schedule the next set of futures for upload
                         for next_file in itertools.islice(iterator, new_tasks):
-                            LOG.info(f"Starting: {next_file}")
+                            LOG.debug(f"Starting: {next_file}")
                             upload_threads[
                                 texec.submit(
                                     putter.protect_and_upload,
@@ -278,7 +278,7 @@ class DataPutter(base.DDSBaseClass):
         self.filehandler.data[file]["size_processed"] = file_info["path_processed"].stat().st_size
 
         if saved:
-            LOG.info(
+            LOG.debug(
                 f"File successfully encrypted: {file}. New location: {file_info['path_processed']}"
             )
             # Update progress bar for upload
@@ -298,7 +298,7 @@ class DataPutter(base.DDSBaseClass):
 
                 if db_updated:
                     all_ok = True
-                    LOG.info(f"File successfully uploaded and added to the database: {file}")
+                    LOG.debug(f"File successfully uploaded and added to the database: {file}")
 
         if not saved or all_ok:
             # Delete temporary processed file locally

--- a/dds_cli/data_putter.py
+++ b/dds_cli/data_putter.py
@@ -73,7 +73,7 @@ def put(
             " • ",
             "[progress.percentage]{task.percentage:>3.1f}%",
             refresh_per_second=2,
-            console=dds_cli.utils.console,
+            console=dds_cli.utils.stderr_console,
         ) as progress:
 
             # Keep track of futures
@@ -199,7 +199,7 @@ class DataPutter(base.DDSBaseClass):
         with Progress(
             "[bold]{task.description}",
             SpinnerColumn(spinner_name="dots12", style="white"),
-            console=dds_cli.utils.console,
+            console=dds_cli.utils.stderr_console,
         ) as progress:
             # Spinner while collecting file info
             wait_task = progress.add_task("Collecting and preparing data", step="prepare")

--- a/dds_cli/data_remover.py
+++ b/dds_cli/data_remover.py
@@ -94,7 +94,7 @@ class DataRemover(base.DDSBaseClass):
             file.unlink()
         except FileNotFoundError as err:
             LOG.exception(str(err))
-            LOG.info("File deletion may have failed. Usage of space may increase.")
+            LOG.warning("File deletion may have failed. Usage of space may increase.")
 
     # Public methods ###################### Public methods #
     @removal_spinner

--- a/dds_cli/s3_connector.py
+++ b/dds_cli/s3_connector.py
@@ -81,7 +81,7 @@ class S3Connector:
             LOG.warning(f"S3 connection failed: {err}")
             raise
 
-        LOG.info(f"Resource :{self.resource}")
+        LOG.debug(f"Resource :{self.resource}")
         return resource
 
     # Static methods ############ Static methods #


### PR DESCRIPTION
1. Switch back rich logging level to info (unless verbose)
2. Make progress bars log to stderr instead of stdout
3. Move some log statements from info to debug if they’re normally not needed for the end user (This is of course a subjective choice)

This will re-enable the messages printed to users for `dds auth info` and `dds ls` which are otherwise muted if the level is set to warning.  