### PR TITLE
Add timestamp localization by using local timezone info

### DIFF
--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 import logging
 import os
 from typing import Tuple, Union, List
+import datetime
 
 # Installed
 import requests
@@ -16,6 +17,8 @@ import simplejson
 from rich.padding import Padding
 from rich.table import Table
 from rich.tree import Tree
+import pytz
+import tzlocal
 
 # Own modules
 from dds_cli import base
@@ -96,6 +99,14 @@ class DataLister(base.DDSBaseClass):
         project_info = resp_json.get("project_info")
         if not project_info:
             raise exceptions.NoDataError("No project info was retrieved. No files to list.")
+
+        for project in project_info:
+            last_updated = pytz.timezone("UTC").localize(
+                datetime.datetime.strptime(project["Last updated"], "%a, %d %b %Y %H:%M:%S GMT")
+            )
+            project["Last updated"] = last_updated.astimezone(tzlocal.get_localzone()).strftime(
+                "%a, %d %b %Y %H:%M:%S %Z"
+            )
 
         # Sort projects according to chosen or default, first ID
         sorted_projects = self.__sort_projects(projects=project_info, sort_by=sort_by)

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -101,12 +101,18 @@ class DataLister(base.DDSBaseClass):
             raise exceptions.NoDataError("No project info was retrieved. No files to list.")
 
         for project in project_info:
-            last_updated = pytz.timezone("UTC").localize(
-                datetime.datetime.strptime(project["Last updated"], "%a, %d %b %Y %H:%M:%S GMT")
-            )
-            project["Last updated"] = last_updated.astimezone(tzlocal.get_localzone()).strftime(
-                "%a, %d %b %Y %H:%M:%S %Z"
-            )
+            try:
+                last_updated = pytz.timezone("UTC").localize(
+                    datetime.datetime.strptime(project["Last updated"], "%a, %d %b %Y %H:%M:%S GMT")
+                )
+            except ValueError as err:
+                raise exceptions.ApiResponseError(
+                    f"Time zone mismatch: Incorrect zone '{project['Last updated'].split()[-1]}'"
+                )
+            else:
+                project["Last updated"] = last_updated.astimezone(tzlocal.get_localzone()).strftime(
+                    "%a, %d %b %Y %H:%M:%S %Z"
+                )
 
         # Sort projects according to chosen or default, first ID
         sorted_projects = self.__sort_projects(projects=project_info, sort_by=sort_by)

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -266,6 +266,7 @@ class TokenFile:
 
     # Private methods ############################################################ Private methods #
     def __token_dates(self):
+        # os.path.getmtime() gets modified time of token file from local, so already localized
         modification_time = datetime.datetime.fromtimestamp(os.path.getmtime(self.token_file))
         age = datetime.datetime.now() - modification_time
         expiration_time = modification_time + dds_cli.TOKEN_MAX_AGE

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ simplejson
 zstandard>=0.15.1
 pyyaml
 pytest
+pytz
+tzlocal

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -119,7 +119,7 @@ def test_list_no_projects_dds_project_ls(ls_runner, list_request):
 
 def list_no_project_specified(ls_runner, list_request, command):
     """Perform test called by tests with different commands."""
-    list_request_OK = list_request(200, return_json=RETURNED_PROJECTS_JSON)
+    list_request_OK = list_request(200, return_json=copy.deepcopy(RETURNED_PROJECTS_JSON))
     result = ls_runner(command)
 
     assert result.exit_code == 0
@@ -164,7 +164,7 @@ def test_list_no_project_specified_dds_project_ls(ls_runner, list_request):
 
 def list_no_project_specified_json(ls_runner, list_request, command):
     """Perform test called by tests with different commands."""
-    list_request_OK = list_request(200, return_json=RETURNED_PROJECTS_JSON)
+    list_request_OK = list_request(200, return_json=copy.deepcopy(RETURNED_PROJECTS_JSON))
     result = ls_runner(command)
 
     assert result.exit_code == 0
@@ -205,7 +205,7 @@ def test_list_no_project_specified_json_dds_project_ls(ls_runner, list_request):
 
 def list_no_project_specified_json_sort(ls_runner, list_request, command):
     """Perform test called by tests with different commands."""
-    list_request_OK = list_request(200, return_json=RETURNED_PROJECTS_JSON)
+    list_request_OK = list_request(200, return_json=copy.deepcopy(RETURNED_PROJECTS_JSON))
     result = ls_runner(command)
 
     assert result.exit_code == 0


### PR DESCRIPTION
Converts the timestamps in UTC received from dds_web to timestamps in the local timezone on the system where the CLI is installed. Should work on UNIX-like and Windows systems, although not tested for Windows.