### PR TITLE
Added obfuscation to the Name_in_Bucket parameter (issue 769 of web)

### DIFF
--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -89,21 +89,6 @@ class DownloadError(Exception):
     """Errors relating to file download."""
 
 
-class S3KeyLengthExceeded(UploadError):
-    """The name in bucket exceeded the allowed 1024 bytes."""
-
-    def __init__(
-        self,
-        filename,
-        message=(
-            "Exceeds allowed limit for combined path "
-            "and name length and can't be stored in the system."
-        ),
-    ):
-        """Init s3 key length error."""
-        super().__init__(f"{filename} {message}")
-
-
 class NoDataError(Exception):
     """Errors when there is no data to do anything with."""
 

--- a/dds_cli/file_handler_local.py
+++ b/dds_cli/file_handler_local.py
@@ -85,16 +85,8 @@ class LocalFileHandler(fh.FileHandler):
         called in the bucket."""
 
         # Generate new file name
-        new_name = str(folder / pathlib.Path(str(uuid.uuid5(uuid.NAMESPACE_X500, filename))))
-
-        # maximum allowed length of S3 object key is 1024 bytes in UTF-8
-        if len(new_name.encode("utf-8")) > 1024:
-            # because UTF-8 is a variable length encoding, some characters may take up 4 bytes.
-            # Also mind that umlauts like ö or å will be encoded to 2 bytes each in Windows/Linux but to 3 bytes each on Mac,
-            # because Windows/Linux use Normal-Form-Composed (NFC) Unicode, MacOS uses Normal-Form-Decomposed (NFD) Unicode.
-            raise exceptions.S3KeyLengthExceeded(str(folder / pathlib.Path(filename)))
-        else:
-            return new_name
+        new_name = f"{uuid.uuid5(uuid.NAMESPACE_X500, str(folder))}{uuid.uuid5(uuid.NAMESPACE_X500, filename)}"
+        return new_name
 
     @staticmethod
     def read_file(file, chunk_size: int = FileSegment.SEGMENT_SIZE_RAW):

--- a/dds_cli/file_handler_local.py
+++ b/dds_cli/file_handler_local.py
@@ -6,11 +6,12 @@
 
 # Standard library
 import hashlib
+import http
 import logging
 import os
 import pathlib
 import uuid
-import http
+import random
 
 # Installed
 import requests
@@ -85,7 +86,7 @@ class LocalFileHandler(fh.FileHandler):
         called in the bucket."""
 
         # Generate new file name
-        new_name = f"{uuid.uuid5(uuid.NAMESPACE_X500, str(folder))}{uuid.uuid5(uuid.NAMESPACE_X500, filename)}"
+        new_name = f"{'%020x' % random.randrange(16**20)}_{uuid.uuid5(uuid.NAMESPACE_X500, str(folder))}{uuid.uuid5(uuid.NAMESPACE_X500, filename)}"
         return new_name
 
     @staticmethod

--- a/dds_cli/file_handler_remote.py
+++ b/dds_cli/file_handler_remote.py
@@ -124,7 +124,9 @@ class RemoteFileHandler(fh.FileHandler):
             / pathlib.Path(x): {
                 **y,
                 "name_in_db": x,
-                "path_downloaded": self.local_destination / pathlib.Path(y["name_in_bucket"]),
+                "path_downloaded": self.local_destination
+                / pathlib.Path(y["subpath"])
+                / pathlib.Path(y["name_in_bucket"]),
             }
             for x, y in files.items()
         }
@@ -140,6 +142,7 @@ class RemoteFileHandler(fh.FileHandler):
                         **k,
                         "name_in_db": j,
                         "path_downloaded": self.local_destination
+                        / pathlib.Path(k["subpath"])
                         / pathlib.Path(k["name_in_bucket"]),
                     }
                     for j, k in y.items()

--- a/dds_cli/file_handler_remote.py
+++ b/dds_cli/file_handler_remote.py
@@ -94,16 +94,13 @@ class RemoteFileHandler(fh.FileHandler):
             raise dds_cli.exceptions.ApiResponseError(response.text)
 
         # Folder info required if specific files requested
-        if all_paths and "folder_contents" not in file_info:
+        if all_paths and not all(x in file_info for x in ["files", "folder_contents", "not_found"]):
             raise dds_cli.exceptions.DDSCLIException(
                 "Error in response. Not enough info returned despite ok request."
             )
 
         folder_contents = file_info.get("folder_contents", {})
         files = file_info.get("files")
-        # Files in response always required
-        if not files:
-            raise dds_cli.exceptions.DDSCLIException("No files in response despite ok request.")
 
         LOG.debug(f"Attempted: \n{all_paths}")
         LOG.debug(f"Files: \n{files}")

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -91,7 +91,7 @@ def format_api_response(response, key, magnitude=None, iec_standard=False):
                 response /= base
         else:
             # utilize the given magnitude
-            response /= base ** magnitude
+            response /= base**magnitude
 
         if key == "Size":
             unit = "B"  # lock


### PR DESCRIPTION
Addresses [issue 769 of the web](https://github.com/ScilifelabDataCentre/dds_web/issues/769)

Added obfuscation to the _Name_in_Bucket_ parameter. Now neither the file's name nor the file's path can be reconstructed from the object's name in the bucket. 

Because the file's path is now also a UUID, exceedance of the 1024 bytes maximum length never happens. Thus, the corresponding exception was removed.

No changes to the web are required for this.