### PR TITLE
Click help: max 100 chrs wide

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -59,6 +59,7 @@ from dds_cli.options import (
 LOG = logging.getLogger()
 
 # Monkey patch click to use rich's logging
+rich_click.core.MAX_WIDTH = 100
 click.Group.format_help = rich_click.rich_format_help
 click.Command.format_help = rich_click.rich_format_help
 


### PR DESCRIPTION
I changed the default maximum width for `rich-click` to be the full width of the terminal.

This PR customises the package to limit the width to 100 characters (or the width of the terminal if less than that).

Personally I think it looks better for `dds` as the majority (all?) of the help messages fit within this width.

The end result is the same as when I originally added the package, before I changed the default.