### PR TITLE
Print error message

### DIFF
--- a/dds_cli/project_creator.py
+++ b/dds_cli/project_creator.py
@@ -78,8 +78,11 @@ class ProjectCreator(base.DDSBaseClass):
 
                 error = next(message for message in messages if message)
 
-                LOG.error(error[0])
-                return created, created_project_id, user_addition_statuses, error[0]
+                if isinstance(error, list):
+                    error = error[0]
+
+                LOG.error(error)
+                return created, created_project_id, user_addition_statuses, error
 
             try:
                 created, created_project_id, user_addition_statuses, error = (


### PR DESCRIPTION
This patch fixes an issue that error messages can be an array or a string.

Before submitting a PR to the `dev` branch:
- [X] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch
- [ ] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 