### PR TITLE
rich-click v1.2.1 at least, handle exception problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Data Delivery System CLI: Changelog
-Please add a _short_ line describing the PR you make, if the PR implements a specific feature or functionality, or refactor. Not needed if you add very small and unnoticable changes. 
+Please add a _short_ line describing the PR you make, if the PR implements a specific feature or functionality, or refactor. Not needed if you add very small and unnoticable changes.
 ## Sprint (2021-08-11 - 2021-08-25)
 * Progress bar glitch fixed by creating console object in utils.py ([#130](https://github.com/ScilifelabDataCentre/dds_cli/pull/130))
 * Log messages about successful checksum verification ([#131](https://github.com/ScilifelabDataCentre/dds_cli/pull/131))
@@ -92,3 +92,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Removed pinned package versions and bumped rick-click, should work for Python 3.7 up to 3.10 ([#288](https://github.com/ScilifelabDataCentre/dds_cli/pull/288))
 * Remove local token when requesting deletion of own account ([297](https://github.com/ScilifelabDataCentre/dds_cli/pull/297)/[303](https://github.com/ScilifelabDataCentre/dds_cli/pull/303))
 * Add Role when listing project users ([#316](https://github.com/ScilifelabDataCentre/dds_cli/pull/316))
+* Pin rich-click `>=1.2.1` to solve exception handling errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ PyNaCl>=1.4.0
 questionary>=1.8.0
 requests>=2.25.1
 rich>=10.0.0
-rich-click>=1.1.0
+rich-click>=1.2.1
 simplejson
 zstandard>=0.15.1
 pyyaml


### PR DESCRIPTION
The DDS cli has a custom exception type based on a click exception. This doesn't provide a click `ctx` context object, as is provided when the exception is generated from the command line. As such, we get an ugly traceback.

Version 1.2.1 of rich-click solves this by making the `ctx` object optional. This PR updates the requirements to require at least that version of rich-cick.

---


Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 