### PR TITLE
Treat "already uploaded" differently from other upload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Remove `--username` option ([#331](https://github.com/ScilifelabDataCentre/dds_cli/pull/331))
 * Add support for the zero-conf environment in dds_web ([#337](https://github.com/ScilifelabDataCentre/dds_cli/pull/337))
 * Increase request timeout to 30 ([#344]https://github.com/ScilifelabDataCentre/dds_cli/pull/344)
+* Make sure "already uploaded" does not give an error output ([#341](https://github.com/ScilifelabDataCentre/dds_cli/pull/341))


### PR DESCRIPTION
Treat "already uploaded" separately from other errors.

Instead of
```
Errors occurred during upload.
If you wish to retry the upload, re-run the `dds data put` command again, specifying the same options as you did now. To also overwrite the files that were uploaded, also add the `--overwrite` flag at the end of the command.

See /code/DataDelivery_2022-03-04_10-52-47/logs/dds_failed_delivery.txt for more information.
```
The output is now
```
Upload completed!
5 files were already uploaded.
```

Fixes #300.

Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 