### PR TITLE
Change url based on what env we are using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Add support for the zero-conf environment in dds_web ([#337](https://github.com/ScilifelabDataCentre/dds_cli/pull/337))
 * Increase request timeout to 30 ([#344]https://github.com/ScilifelabDataCentre/dds_cli/pull/344)
 * Make sure "already uploaded" does not give an error output ([#341](https://github.com/ScilifelabDataCentre/dds_cli/pull/341))
+* URL in the logo changing with DDS_CLI_ENV ([#349](https://github.com/ScilifelabDataCentre/dds_cli/pull/349))

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -80,7 +80,9 @@ dds_cli.utils.stderr_console.print(
     "[green]     ︵",
     "\n[green] ︵ (  )   ︵",
     "\n[green](  ) ) (  (  )[/]   [bold]SciLifeLab Data Delivery System",
-    "\n[green] ︶  (  ) ) ([/]    [blue][link={0}]{0}/[/link]".format(dds_url[:dds_url.index("/", 7)]),
+    "\n[green] ︶  (  ) ) ([/]    [blue][link={0}]{0}/[/link]".format(
+        dds_url[: dds_url.index("/", 7)]
+    ),
     f"\n[green]      ︶ (  )[/]    [dim]Version {dds_cli.__version__}",
     "\n[green]          ︶",
     highlight=False,

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -81,7 +81,7 @@ dds_cli.utils.stderr_console.print(
     "\n[green] ︵ (  )   ︵",
     "\n[green](  ) ) (  (  )[/]   [bold]SciLifeLab Data Delivery System",
     "\n[green] ︶  (  ) ) ([/]    [blue][link={0}]{0}/[/link]".format(
-        dds_url[: dds_url.index("/", 7)]
+        dds_url[: dds_url.index("/", 8)]
     ),
     f"\n[green]      ︶ (  )[/]    [dim]Version {dds_cli.__version__}",
     "\n[green]          ︶",

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -74,12 +74,13 @@ click.rich_click.MAX_WIDTH = 100
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # ##
 
 
+dds_url = dds_cli.DDSEndpoint.BASE_ENDPOINT
 # Print header to STDERR
 dds_cli.utils.stderr_console.print(
     "[green]     ︵",
     "\n[green] ︵ (  )   ︵",
     "\n[green](  ) ) (  (  )[/]   [bold]SciLifeLab Data Delivery System",
-    "\n[green] ︶  (  ) ) ([/]    [blue][link={0}]{0}[/link]".format(dds_cli.__url__),
+    "\n[green] ︶  (  ) ) ([/]    [blue][link={0}]{0}/[/link]".format(dds_url[:dds_url.index("/", 7)]),
     f"\n[green]      ︶ (  )[/]    [dim]Version {dds_cli.__version__}",
     "\n[green]          ︶",
     highlight=False,


### PR DESCRIPTION
Makes the URL in the logo change depending on what `DDS_CLI_ENV` is set to.

```
root@1105fd8508d9:/code# dds auth info
     ︵
 ︵ (  )   ︵
(  ) ) (  (  )   SciLifeLab Data Delivery System
 ︶  (  ) ) (    http://dds_backend:5000/
      ︶ (  )    Version 0.0.10
          ︶
Current user: unituser_1
INFO     ✅  Token is OK! ✅
INFO     ✅  Token will expire in 1 day 23 hours 49 minutes! ✅
```

Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 