### PR TITLE
Print error message when there are failed emails during project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,3 +99,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Increase request timeout to 30 ([#344]https://github.com/ScilifelabDataCentre/dds_cli/pull/344)
 * Make sure "already uploaded" does not give an error output ([#341](https://github.com/ScilifelabDataCentre/dds_cli/pull/341))
 * URL in the logo changing with DDS_CLI_ENV ([#349](https://github.com/ScilifelabDataCentre/dds_cli/pull/349))
+* Show message "Any users with errors were not added to the project" when emails failed to validate during project creation ([#356](https://github.com/ScilifelabDataCentre/dds_cli/pull/356))

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -734,7 +734,9 @@ def create(
                 if user_addition_messages:
                     for msg in user_addition_messages:
                         dds_cli.utils.console.print(msg)
-                    dds_cli.utils.console.print("[red]Any users with errors were not added to the project[/red]")
+                    dds_cli.utils.console.print(
+                        "[red]Any users with errors were not added to the project[/red]"
+                    )
     except (
         dds_cli.exceptions.APIError,
         dds_cli.exceptions.AuthenticationError,

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -734,6 +734,7 @@ def create(
                 if user_addition_messages:
                     for msg in user_addition_messages:
                         dds_cli.utils.console.print(msg)
+                    dds_cli.utils.console.print("[red]Any users with errors were not added to the project[/red]")
     except (
         dds_cli.exceptions.APIError,
         dds_cli.exceptions.AuthenticationError,


### PR DESCRIPTION
Give correct response when there are failed emails during validation

With https://github.com/ScilifelabDataCentre/dds_web/pull/1014:
```
$ dds project create -t t -d d -pi p --researcher asd@asd --owner asd@adsad
     ︵
 ︵ (  )   ︵
(  ) ) (  (  )   SciLifeLab Data Delivery System
 ︶  (  ) ) (    http://dds_backend:5000/
      ︶ (  )    Version 0.0.10
          ︶
Current user: unituser_1
Project created with id: someunit00023
Error for asd@adsad: {'email': ['Not a valid email address.']}
Error for asd@asd: {'email': ['Not a valid email address.']}
```

With this pr:
```
$ dds project create -t t -d d -pi p --researcher asd@asd --owner asd@adsad
     ︵
 ︵ (  )   ︵
(  ) ) (  (  )   SciLifeLab Data Delivery System
 ︶  (  ) ) (    http://dds_backend:5000/
      ︶ (  )    Version 0.0.10
          ︶
Current user: unituser_1
Project created with id: someunit00023
Error for asd@adsad: {'email': ['Not a valid email address.']}
Error for asd@asd: {'email': ['Not a valid email address.']}
Any users with errors were not added to the project
```


Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 