### PR TITLE
Add confirmation in case of project deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Make sure "already uploaded" does not give an error output ([#341](https://github.com/ScilifelabDataCentre/dds_cli/pull/341))
 * URL in the logo changing with DDS_CLI_ENV ([#349](https://github.com/ScilifelabDataCentre/dds_cli/pull/349))
 * Show message "Any users with errors were not added to the project" when emails failed to validate during project creation ([#356](https://github.com/ScilifelabDataCentre/dds_cli/pull/356))
+* Ask user confirmation for project abort, archive and delete([#357](https://github.com/ScilifelabDataCentre/dds_cli/pull/357))

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -472,7 +472,7 @@ def delete_user(click_ctx, email, self):
     Specify the e-mail address as argument to the main command to initiate the removal process.
     """
     if click_ctx.get("NO_PROMPT", False):
-        pass
+        proceed_deletion = True
     else:
         if not self:
             proceed_deletion = rich.prompt.Confirm.ask(
@@ -858,21 +858,25 @@ def archive_project(click_ctx, project):
 
     This deletes all project data.
     """
-    try:
-        with dds_cli.project_status.ProjectStatusManager(
-            project=project,
-            no_prompt=click_ctx.get("NO_PROMPT", False),
-            token_path=click_ctx.get("TOKEN_PATH"),
-        ) as updater:
-            updater.update_status(new_status="Archived")
-    except (
-        dds_cli.exceptions.APIError,
-        dds_cli.exceptions.AuthenticationError,
-        dds_cli.exceptions.DDSCLIException,
-        dds_cli.exceptions.ApiResponseError,
-    ) as err:
-        LOG.error(err)
-        sys.exit(1)
+    proceed_deletion = dds_cli.utils.get_deletion_confirmation(
+        click_ctx.get("NO_PROMPT", False), "archive", project
+    )
+    if proceed_deletion:
+        try:
+            with dds_cli.project_status.ProjectStatusManager(
+                project=project,
+                no_prompt=click_ctx.get("NO_PROMPT", False),
+                token_path=click_ctx.get("TOKEN_PATH"),
+            ) as updater:
+                updater.update_status(new_status="Archived")
+        except (
+            dds_cli.exceptions.APIError,
+            dds_cli.exceptions.AuthenticationError,
+            dds_cli.exceptions.DDSCLIException,
+            dds_cli.exceptions.ApiResponseError,
+        ) as err:
+            LOG.error(err)
+            sys.exit(1)
 
 
 # -- dds project status delete -- #
@@ -885,21 +889,25 @@ def delete_project(click_ctx, project):
 
     This deletes all project data.
     """
-    try:
-        with dds_cli.project_status.ProjectStatusManager(
-            project=project,
-            no_prompt=click_ctx.get("NO_PROMPT", False),
-            token_path=click_ctx.get("TOKEN_PATH"),
-        ) as updater:
-            updater.update_status(new_status="Deleted")
-    except (
-        dds_cli.exceptions.APIError,
-        dds_cli.exceptions.AuthenticationError,
-        dds_cli.exceptions.DDSCLIException,
-        dds_cli.exceptions.ApiResponseError,
-    ) as err:
-        LOG.error(err)
-        sys.exit(1)
+    proceed_deletion = dds_cli.utils.get_deletion_confirmation(
+        click_ctx.get("NO_PROMPT", False), "delete", project
+    )
+    if proceed_deletion:
+        try:
+            with dds_cli.project_status.ProjectStatusManager(
+                project=project,
+                no_prompt=click_ctx.get("NO_PROMPT", False),
+                token_path=click_ctx.get("TOKEN_PATH"),
+            ) as updater:
+                updater.update_status(new_status="Deleted")
+        except (
+            dds_cli.exceptions.APIError,
+            dds_cli.exceptions.AuthenticationError,
+            dds_cli.exceptions.DDSCLIException,
+            dds_cli.exceptions.ApiResponseError,
+        ) as err:
+            LOG.error(err)
+            sys.exit(1)
 
 
 # -- dds project status abort -- #
@@ -912,21 +920,25 @@ def abort_project(click_ctx, project):
 
     This deletes all project data.
     """
-    try:
-        with dds_cli.project_status.ProjectStatusManager(
-            project=project,
-            no_prompt=click_ctx.get("NO_PROMPT", False),
-            token_path=click_ctx.get("TOKEN_PATH"),
-        ) as updater:
-            updater.update_status(new_status="Archived", is_aborted=True)
-    except (
-        dds_cli.exceptions.APIError,
-        dds_cli.exceptions.AuthenticationError,
-        dds_cli.exceptions.DDSCLIException,
-        dds_cli.exceptions.ApiResponseError,
-    ) as err:
-        LOG.error(err)
-        sys.exit(1)
+    proceed_deletion = dds_cli.utils.get_deletion_confirmation(
+        click_ctx.get("NO_PROMPT", False), "abort", project
+    )
+    if proceed_deletion:
+        try:
+            with dds_cli.project_status.ProjectStatusManager(
+                project=project,
+                no_prompt=click_ctx.get("NO_PROMPT", False),
+                token_path=click_ctx.get("TOKEN_PATH"),
+            ) as updater:
+                updater.update_status(new_status="Archived", is_aborted=True)
+        except (
+            dds_cli.exceptions.APIError,
+            dds_cli.exceptions.AuthenticationError,
+            dds_cli.exceptions.DDSCLIException,
+            dds_cli.exceptions.ApiResponseError,
+        ) as err:
+            LOG.error(err)
+            sys.exit(1)
 
 
 # ACCESS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ACCESS #

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -201,6 +201,7 @@ class User:
                     response = requests.get(
                         dds_cli.DDSEndpoint.DISPLAY_USER_INFO,
                         headers={"Authorization": f"Bearer {token}"},
+                        timeout=dds_cli.DDSEndpoint.TIMEOUT,
                     )
                     # Get response
                     response_json = response.json()

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -181,3 +181,16 @@ def readable_timedelta(duration):
         return " ".join(time_parts)
     else:
         return "less than a minute"
+
+
+def get_deletion_confirmation(no_prompt, action, project):
+    if no_prompt:
+        return True
+
+    question = f"Are you sure you want to {action} {project}? All its contents "
+    if action in ["delete", "abort"]:
+        question = question + "and metainfo "
+    question += "will be deleted!"
+
+    proceed_deletion = rich.prompt.Confirm.ask(question)
+    return proceed_deletion


### PR DESCRIPTION
Added a missed timeout and activated the no_prompt in user deletion too.

Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 