### PR TITLE
remove duplicate message after response error

### DIFF
--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -93,7 +93,6 @@ class ApiResponseError(Exception):
 
     def __init__(self, message):
         """Log and raise."""
-        LOG.exception(message)
         super().__init__(message)
 
 


### PR DESCRIPTION
When you try to use the `dds auth login` function more than 10 times per hour:
```
INFO     Attempting to renew the session token                    
DDS username: superadmin
DDS password: 
ERROR    API returned an error: Too many authentication requests  
         in one hour                                              
         NoneType: None                                           
ERROR    API returned an error: Too many authentication requests  
         in one hour          
```
With this PR (there was a log line in one of the custom exceptions):
```
INFO     Attempting to renew the session token                    
DDS username: superadmin
DDS password: 
ERROR    API returned an error: Too many authentication requests  
         in one hour      
```

Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [ - ] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 