### PR TITLE
Change error to avoid double message

### DIFF
--- a/dds_cli/s3_connector.py
+++ b/dds_cli/s3_connector.py
@@ -17,6 +17,7 @@ import botocore
 # Own modules
 from dds_cli import DDSEndpoint
 from dds_cli import utils
+from dds_cli import exceptions
 
 ###############################################################################
 # LOGGING ########################################################### LOGGING #
@@ -102,9 +103,8 @@ class S3Connector:
 
         # Error
         if not response.ok:
-            message = f"Failed retrieving Safespring project name. Server response: {response.text}"
-            LOG.warning(message)
-            raise SystemExit(message)  # TODO: Change
+            message = f"Connection error: {response.text}"
+            raise exceptions.ApiResponseError(message)  # TODO: Change
 
         # Get s3 info
         s3info = utils.get_json_response(response=response)


### PR DESCRIPTION
Change the "PUT" message for a bad project name from:
```
WARNING  Failed retrieving Safespring project name. Server response: {"message": "The specified project does not exist."}
Failed retrieving Safespring project name. Server response: {"message": "The specified project does not exist."
```
to:
```
ERROR    Connection error: {"message": "The specified project does not exist."}
```
Before submitting a PR to the `dev` branch:
- [X] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch
- [-] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 