### PR TITLE
utils.calculate_magnitude can now handle vastly different project sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * URL in the logo changing with DDS_CLI_ENV ([#349](https://github.com/ScilifelabDataCentre/dds_cli/pull/349))
 * Show message "Any users with errors were not added to the project" when emails failed to validate during project creation ([#356](https://github.com/ScilifelabDataCentre/dds_cli/pull/356))
 * Ask user confirmation for project abort, archive and delete([#357](https://github.com/ScilifelabDataCentre/dds_cli/pull/357))
-* Replaced the default help messages of Click for the `--version` and `--help` options as requested in [issue 338](https://github.com/scilifelabdatacentre/dds_web/issues/338).
+* Replaced the default help messages of Click for the `--version` and `--help` options as requested in [issue 338](https://github.com/scilifelabdatacentre/dds_cli/issues/338).
 * Explicit error message for `--destination` when the path exists ([#371](https://github.com/ScilifelabDataCentre/dds_cli/pull/371))
 * Escape variables that are printed in the cli (avoiding e.g. hidden text and bad coloring) ([#364](https://github.com/ScilifelabDataCentre/dds_cli/pull/364))
 
@@ -132,3 +132,5 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * New unit group command unit module ([#398](https://github.com/ScilifelabDataCentre/dds_cli/pull/398))
 * `--unit` option for Super Admins to list unit users ([#397](https://github.com/ScilifelabDataCentre/dds_cli/pull/397))
 * Removed `dds project status abort` and added `--abort` flag to `dds project status archive` ()
+* Escape variables that are printed in the cli (avoiding e.g. hidden text and bad coloring) ([#364](https://github.com/ScilifelabDataCentre/dds_cli/pull/364)).
+* Handle the edge case that a user has two projects with a extremely different size available to them in the `utils.calculate_magnitude` function. Introduce a new option `-up / --unit-prefix` to format the unit prefixes used in `utils.format_api_response` [issue 1043](https://github.com/scilifelabdatacentre/dds_web/issues/1043).

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -1307,14 +1307,13 @@ def get_data(
 # Options
 @project_option(required=True)
 @folder_option(help_message="List contents in this project folder.")
-@unit_prefix_option
 # Flags
 @json_flag(help_message="Output in JSON format.")
 @size_flag(help_message="Show size of project contents.")
 @tree_flag(help_message="Display the entire project(s) directory tree.")
 @users_flag(help_message="Display users associated with a project(Requires a project id).")
 @click.pass_context
-def list_data(ctx, project, folder, unitprefix, json, size, tree, users):
+def list_data(ctx, project, folder, json, size, tree, users):
     """List project contents.
 
     Same as dds ls [PROJECT ID].
@@ -1323,7 +1322,6 @@ def list_data(ctx, project, folder, unitprefix, json, size, tree, users):
         list_projects_and_contents,
         project=project,
         folder=folder,
-        unitprefix=unitprefix,
         size=size,
         tree=tree,
         users=users,

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -46,6 +46,7 @@ from dds_cli.options import (
     source_option,
     source_path_file_option,
     token_path_option,
+    unit_prefix_option,
     break_on_fail_flag,
     json_flag,
     nomail_flag,
@@ -160,6 +161,7 @@ def dds_main(click_ctx, verbose, log_file, no_prompt, token_path):
 # Options
 @project_option(required=False)
 @sort_projects_option()
+@unit_prefix_option()
 @folder_option(help_message="List contents of this project folder.")
 # Flags
 @json_flag(help_message="Output in JSON format.")
@@ -170,7 +172,7 @@ def dds_main(click_ctx, verbose, log_file, no_prompt, token_path):
 @click.option("--projects", "-lp", is_flag=True, help="List all project connected to your account.")
 @click.pass_obj
 def list_projects_and_contents(
-    click_ctx, project, folder, sort, json, size, tree, usage, users, projects
+    click_ctx, project, folder, sort, unitprefix, json, size, tree, usage, users, projects
 ):
     """List the projects you have access to or the project contents.
 
@@ -189,7 +191,7 @@ def list_projects_and_contents(
                 json=json,
                 token_path=click_ctx.get("TOKEN_PATH"),
             ) as lister:
-                projects = lister.list_projects(sort_by=sort)
+                projects = lister.list_projects(sort_by=sort, unitprefix=unitprefix)
                 if json:
                     dds_cli.utils.console.print_json(data=projects)
                 else:
@@ -671,16 +673,17 @@ def project_group_command(_):
 @project_group_command.command(name="ls")
 # Options
 @sort_projects_option()
+@unit_prefix_option()
 # Flags
 @usage_flag(help_message="Show the usage for available projects, in GBHours and cost.")
 @json_flag(help_message="Output project list as json.")  # users, json, tree
 @click.pass_context
-def list_projects(ctx, json, sort, usage):
+def list_projects(ctx, json, sort, unitprefix, usage):
     """List all projects you have access to in the DDS.
 
     Calls the `dds ls` function.
     """
-    ctx.invoke(list_projects_and_contents, json=json, sort=sort, usage=usage)
+    ctx.invoke(list_projects_and_contents, json=json, sort=sort, unitprefix=unitprefix, usage=usage)
 
 
 # -- dds project create -- #
@@ -1304,13 +1307,14 @@ def get_data(
 # Options
 @project_option(required=True)
 @folder_option(help_message="List contents in this project folder.")
+@unit_prefix_option
 # Flags
 @json_flag(help_message="Output in JSON format.")
 @size_flag(help_message="Show size of project contents.")
 @tree_flag(help_message="Display the entire project(s) directory tree.")
 @users_flag(help_message="Display users associated with a project(Requires a project id).")
 @click.pass_context
-def list_data(ctx, project, folder, json, size, tree, users):
+def list_data(ctx, project, folder, unitprefix, json, size, tree, users):
     """List project contents.
 
     Same as dds ls [PROJECT ID].
@@ -1319,6 +1323,7 @@ def list_data(ctx, project, folder, json, size, tree, users):
         list_projects_and_contents,
         project=project,
         folder=folder,
+        unitprefix=unitprefix,
         size=size,
         tree=tree,
         users=users,

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -506,8 +506,8 @@ class DataLister(base.DDSBaseClass):
                 "footer": dds_cli.utils.format_api_response(
                     total_size,
                     key="Size",
-                    iec_standard=True if unitprefix in ["auto-iec", "const-iec"] else False,
-                    skip=True if unitprefix == "off" else False,
+                    iec_standard=unitprefix in ["auto-iec", "const-iec"],
+                    skip=unitprefix == "off",
                 ),
                 "overflow": "ellipsis",
             }
@@ -522,8 +522,8 @@ class DataLister(base.DDSBaseClass):
                         "footer": dds_cli.utils.format_api_response(
                             usage_info["usage"],
                             key="Usage",
-                            iec_standard=True if unitprefix in ["auto-iec", "const-iec"] else False,
-                            skip=True if unitprefix == "off" else False,
+                            iec_standard=unitprefix in ["auto-iec", "const-iec"],
+                            skip=unitprefix == "off",
                         ),
                         "overflow": "ellipsis",
                     },
@@ -533,8 +533,8 @@ class DataLister(base.DDSBaseClass):
                         "footer": dds_cli.utils.format_api_response(
                             usage_info["cost"],
                             key="Cost",
-                            iec_standard=True if unitprefix in ["auto-iec", "const-iec"] else False,
-                            skip=True if unitprefix == "off" else False,
+                            iec_standard=unitprefix in ["auto-iec", "const-iec"],
+                            skip=unitprefix == "off",
                         ),
                         "overflow": "ellipsis",
                     },
@@ -584,8 +584,8 @@ class DataLister(base.DDSBaseClass):
         magnitudes = dds_cli.utils.calculate_magnitude(
             sorted_projects,
             column_formatting.keys(),
-            iec_standard=True if unitprefix in ["auto-iec", "const-iec"] else False,
-            force=True if unitprefix in ["const", "const-iec"] else False,
+            iec_standard=unitprefix in ["auto-iec", "const-iec"],
+            force=unitprefix in ["const", "const-iec"],
         )
 
         # Add all column values for each row to table

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -597,8 +597,8 @@ class DataLister(base.DDSBaseClass):
                             proj[i],
                             i,
                             magnitudes[i],
-                            iec_standard=True if unitprefix in ["auto-iec", "const-iec"] else False,
-                            skip=True if unitprefix == "off" else False,
+                            iec_standard=unitprefix in ["auto-iec", "const-iec"],
+                            skip=unitprefix == "off",
                         )
                     )
                     for i in column_formatting

--- a/dds_cli/options.py
+++ b/dds_cli/options.py
@@ -187,6 +187,35 @@ def token_path_option(
     )
 
 
+def unit_prefix_option(
+    long="--unit-prefixes",
+    short="-up",
+    name="unitprefix",
+    choices=["auto", "auto-iec", "const", "const-iec", "off"],
+    case_sensitive=False,
+    default="auto",
+    required=False,
+    help_message="Use unit prefixes in order to reduce the number of digits. For Bytes, the SI prefixes can be replaced by powers of 1024 (IEC prefixes).",
+):
+    """
+    Unit prefix option standard definition.
+
+    Use as decorator for commands to dds ls and dds project list.
+    """
+    return click.option(
+        long,
+        short,
+        name,
+        type=click.Choice(
+            choices=choices,
+            case_sensitive=case_sensitive,
+        ),
+        default=default,
+        required=required,
+        help=help_message,
+    )
+
+
 # Flags
 def break_on_fail_flag(
     help_message,

--- a/dds_cli/options.py
+++ b/dds_cli/options.py
@@ -195,7 +195,7 @@ def unit_prefix_option(
     case_sensitive=False,
     default="auto",
     required=False,
-    help_message="Use unit prefixes in order to reduce the number of digits. For Bytes, the SI prefixes can be replaced by powers of 1024 (IEC prefixes).",
+    help_message="Configure the use of unit prefixes (Kilo, Mega, Giga): A consistent scale is enforced with 'const', while 'auto' adapts best to the values on display. For bytes, binary instead of decadic prefixes are set using -iec modifier.",
 ):
     """
     Unit prefix option standard definition.

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -198,7 +198,7 @@ def format_api_response(response, key, magnitude=None, iec_standard=False, skip=
         unit = units.get(key, "")
 
         if not skip:
-            response = float("{:.3g}".format(response))
+            response = float(response)
             mag = 0
 
             if key in ["Size", "Usage"]:

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -165,9 +165,11 @@ def calculate_magnitude(projects, keys, iec_standard=False):
 
             # exclude values smaller than base, such that empty projects don't interfer with
             # the calculation ensures that a minimum can be calculated if no val is larger than base
-            minimum = (lambda x: min(x) if x else 1)([val for val in values if val >= base])
-            maximum = (lambda x: max(x) if x else 1)([val for val in values if val >= base])
-            magmin = magmax = 0
+            minimum, maximum = (lambda x: (min(x), max(x)) if x else 1)(
+                [val for val in values if val >= base]
+            )
+            magmin = 0
+            magmax = 0
 
             while abs(minimum) >= base:
                 magmin += 1

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -165,7 +165,7 @@ def calculate_magnitude(projects, keys, iec_standard=False):
 
             # exclude values smaller than base, such that empty projects don't interfer with
             # the calculation ensures that a minimum can be calculated if no val is larger than base
-            minimum, maximum = (lambda x: (min(x), max(x)) if x else 1)(
+            minimum, maximum = (lambda x: (min(x), max(x)) if x else (1, 1))(
                 [val for val in values if val >= base]
             )
             magmin = 0

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -180,7 +180,7 @@ def calculate_magnitude(projects, keys, iec_standard=False):
                 maximum /= base
 
             # skip consistent scaling of magnitudes if the values are too far off.
-            magnitudes[key] = magmin if (magmax - magmin <= 2) else None
+            magnitudes[key] = magmin if (magmax - magmin <= 1) else None
     return magnitudes
 
 

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -166,13 +166,19 @@ def calculate_magnitude(projects, keys, iec_standard=False):
             # exclude values smaller than base, such that empty projects don't interfer with
             # the calculation ensures that a minimum can be calculated if no val is larger than base
             minimum = (lambda x: min(x) if x else 1)([val for val in values if val >= base])
-            mag = 0
+            maximum = (lambda x: max(x) if x else 1)([val for val in values if val >= base])
+            magmin = magmax = 0
 
             while abs(minimum) >= base:
-                mag += 1
+                magmin += 1
                 minimum /= base
 
-            magnitudes[key] = mag
+            while abs(maximum) >= base:
+                magmax += 1
+                maximum /= base
+
+            # skip consistent scaling of magnitudes if the values are too far off.
+            magnitudes[key] = magmin if (magmax - magmin <= 2) else None
     return magnitudes
 
 


### PR DESCRIPTION
Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Handle the edge case that a user has two projects with a extremely different size available to them in the utils.calculate_magnitude function

- "auto": Use a consistent unit for all projects unless the variation is too big, in SI units (base 10). 
- "auto-iec": Use consistent unit for all projects unless the variation is too big, in IEC units (base 2). 
- "const": Use consistent unit for all projects, in SI units (base 10). 
- "const-iec": Use consistent unit for all projects, in IEC units (base 2). 
- "off": Display the project sizes in bytes, no further unit simplification."