### PR TITLE
Set file permissions using icacls on Windows, no check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,3 +128,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * New `dds user ls` command for listing unit users ([#384](https://github.com/ScilifelabDataCentre/dds_cli/pull/384))
 * When using `dds project access fix`, list the projects which where not possible to update access in ([#379](https://github.com/ScilifelabDataCentre/dds_cli/pull/379))
 * New `--mount-dir` option for `dds data put` where the `DataDelivery...` folders will be created if specified ([#393](https://github.com/ScilifelabDataCentre/dds_cli/pull/393))
+* File permission fixing for the token on Windows ([#395](https://github.com/ScilifelabDataCentre/dds_cli/pull/395))

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -252,7 +252,7 @@ class TokenFile:
     def save_token(self, token):
         """Saves the token to the token file."""
 
-        if self.token_file.is_file():
+        if not self.token_file.is_file():
             self.token_file.touch(mode=0o600)
 
         self.check_token_file_permissions()

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -13,6 +13,7 @@ import pathlib
 import requests
 import simplejson
 import stat
+import subprocess
 
 # Installed
 import rich
@@ -251,7 +252,7 @@ class TokenFile:
     def save_token(self, token):
         """Saves the token to the token file."""
 
-        if not self.token_file.is_file():
+        if self.token_file.is_file():
             self.token_file.touch(mode=0o600)
 
         self.check_token_file_permissions()
@@ -259,6 +260,18 @@ class TokenFile:
         with self.token_file.open("w") as file:
             file.write(token)
 
+        if os.name == "nt":
+            cli_username = os.environ.get("USERNAME")
+            try:
+                subprocess.check_call([
+                    "icacls.exe",
+                    str(self.token_file),
+                    "/inheritance:r",
+                    "/grant", f"{cli_username}:(R,W)"],
+                                      stdout=subprocess.DEVNULL,
+                                      stderr=subprocess.DEVNULL)
+            except subprocess.CalledProcessError as exc:
+                LOG.error("Failed to set token file permissions")
         LOG.debug("New token saved to file.")
 
     def delete_token(self):
@@ -273,13 +286,16 @@ class TokenFile:
 
         Returns None otherwise.
         """
-        st_mode = os.stat(self.token_file).st_mode
-        permissions_octal = oct(stat.S_IMODE(st_mode))
-        permissions_readable = stat.filemode(st_mode)
-        if permissions_octal != "0o600":
-            raise exceptions.DDSCLIException(
-                message=f"Token file permissions are not properly set, (got {permissions_readable} instead of required '-rw-------'). Please remove {self.token_file} and rerun the command."
-            )
+        if os.name != "nt":
+            st_mode = os.stat(self.token_file).st_mode
+            permissions_octal = oct(stat.S_IMODE(st_mode))
+            permissions_readable = stat.filemode(st_mode)
+            if permissions_octal != "0o600":
+                raise exceptions.DDSCLIException(
+                    message=f"Token file permissions are not properly set, (got {permissions_readable} instead of required '-rw-------'). Please remove {self.token_file} and rerun the command."
+                )
+        else:
+            LOG.info("Unable to confirm whether file permissions are correct on Windows.")
 
     def token_expired(self, token):
         """Check if the token has expired or is about to expire soon based on the UTC time.

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -263,13 +263,17 @@ class TokenFile:
         if os.name == "nt":
             cli_username = os.environ.get("USERNAME")
             try:
-                subprocess.check_call([
-                    "icacls.exe",
-                    str(self.token_file),
-                    "/inheritance:r",
-                    "/grant", f"{cli_username}:(R,W)"],
-                                      stdout=subprocess.DEVNULL,
-                                      stderr=subprocess.DEVNULL)
+                subprocess.check_call(
+                    [
+                        "icacls.exe",
+                        str(self.token_file),
+                        "/inheritance:r",
+                        "/grant",
+                        f"{cli_username}:(R,W)",
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
             except subprocess.CalledProcessError as exc:
                 LOG.error("Failed to set token file permissions")
         LOG.debug("New token saved to file.")


### PR DESCRIPTION
Fix file permissions for token creation on Windows.
The internal check is skipped since it's not compatible with Windows.

To check whether it's correct:
```
icacls .dds_cli_token
```
Should only be one entry: `(your username): (R,W)`

Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 