### PR TITLE
Authentication text

### DIFF
--- a/dds_cli/auth.py
+++ b/dds_cli/auth.py
@@ -40,7 +40,9 @@ class Auth(base.DDSBaseClass):
             token = token_file.read_token()
             token_file.token_report(token=token)
         else:
-            LOG.info("[red]No saved token found, or token has expired, proceeding with authentication![/red]")
+            LOG.info(
+                "[red]No saved token found, or token has expired, proceeding with authentication![/red]"
+            )
 
     def logout(self):
         token_file = user.TokenFile(token_path=self.token_path)

--- a/dds_cli/auth.py
+++ b/dds_cli/auth.py
@@ -41,7 +41,7 @@ class Auth(base.DDSBaseClass):
             token_file.token_report(token=token)
         else:
             LOG.info(
-                "[red]No saved token found, or token has expired, proceeding with authentication![/red]"
+                "[red]No saved token found, or token has expired. Authenticate yourself with `dds auth login` to use this functionality.![/red]"
             )
 
     def logout(self):

--- a/dds_cli/auth.py
+++ b/dds_cli/auth.py
@@ -40,7 +40,7 @@ class Auth(base.DDSBaseClass):
             token = token_file.read_token()
             token_file.token_report(token=token)
         else:
-            LOG.error("[red]No saved authentication token found![/red]")
+            LOG.info("[red]No saved token found, or token has expired, proceeding with authentication![/red]")
 
     def logout(self):
         token_file = user.TokenFile(token_path=self.token_path)


### PR DESCRIPTION
This patch updates the authentication text and switches "LOG.error" to "LOG.info".

Fixes #387.

Before submitting a PR to the `dev` branch:
- [X] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG