### PR TITLE
changed from aborted command to an abort flag in archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * New `--mount-dir` option for `dds data put` where the `DataDelivery...` folders will be created if specified ([#393](https://github.com/ScilifelabDataCentre/dds_cli/pull/393))
 * New unit group command unit module ([#398](https://github.com/ScilifelabDataCentre/dds_cli/pull/398))
 * `--unit` option for Super Admins to list unit users ([#397](https://github.com/ScilifelabDataCentre/dds_cli/pull/397))
+* Removed `dds project status abort` and added `--abort` flag to `dds project status archive` ()

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -891,8 +891,16 @@ def retract_project(click_ctx, project):
 @project_status.command(name="archive", no_args_is_help=True)
 # Options
 @project_option(required=True)
+# Flags
+@click.option(
+    "--abort",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Something has one wrong in the project.",
+)
 @click.pass_obj
-def archive_project(click_ctx, project: str):
+def archive_project(click_ctx, project: str, abort: bool = False):
     """Manually archive a released project.
 
     This deletes all project data.
@@ -909,7 +917,7 @@ def archive_project(click_ctx, project: str):
                 no_prompt=click_ctx.get("NO_PROMPT", False),
                 token_path=click_ctx.get("TOKEN_PATH"),
             ) as updater:
-                updater.update_status(new_status="Archived")
+                updater.update_status(new_status="Archived", is_aborted=abort)
         except (
             dds_cli.exceptions.APIError,
             dds_cli.exceptions.AuthenticationError,
@@ -943,39 +951,6 @@ def delete_project(click_ctx, project: str):
                 token_path=click_ctx.get("TOKEN_PATH"),
             ) as updater:
                 updater.update_status(new_status="Deleted")
-        except (
-            dds_cli.exceptions.APIError,
-            dds_cli.exceptions.AuthenticationError,
-            dds_cli.exceptions.DDSCLIException,
-            dds_cli.exceptions.ApiResponseError,
-        ) as err:
-            LOG.error(err)
-            sys.exit(1)
-
-
-# -- dds project status abort -- #
-@project_status.command(name="abort", no_args_is_help=True)
-# Options
-@project_option(required=True)
-@click.pass_obj
-def abort_project(click_ctx, project: str):
-    """Abort a released project.
-
-    This deletes all project data.
-    """
-    proceed_deletion = (
-        True
-        if click_ctx.get("NO_PROMPT", False)
-        else dds_cli.utils.get_deletion_confirmation(action="abort", project=project)
-    )
-    if proceed_deletion:
-        try:
-            with dds_cli.project_status.ProjectStatusManager(
-                project=project,
-                no_prompt=click_ctx.get("NO_PROMPT", False),
-                token_path=click_ctx.get("TOKEN_PATH"),
-            ) as updater:
-                updater.update_status(new_status="Archived", is_aborted=True)
         except (
             dds_cli.exceptions.APIError,
             dds_cli.exceptions.AuthenticationError,


### PR DESCRIPTION
After discussions with @alneberg I decided to remove the `abort` command and add the `--abort` flag to the `archive` command. The flag is optional and indicates that something has gone wrong. 

Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 