### PR TITLE
Fix size usage cost 

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -161,6 +161,17 @@ def dds_main(click_ctx, verbose, log_file, no_prompt, token_path):
 @project_option(required=False)
 @sort_projects_option()
 @folder_option(help_message="List contents of this project folder.")
+@click.option(
+    "--binary",
+    "-b",
+    required=False,
+    is_flag=True,
+    default=False,
+    help=(
+        "Use binary unit prefixes (e.g. KiB instead of KB, "
+        "MiB instead of MB) for size and usage columns."
+    ),
+)
 # Flags
 @json_flag(help_message="Output in JSON format.")
 @size_flag(help_message="Show size of project contents.")
@@ -170,7 +181,7 @@ def dds_main(click_ctx, verbose, log_file, no_prompt, token_path):
 @click.option("--projects", "-lp", is_flag=True, help="List all project connected to your account.")
 @click.pass_obj
 def list_projects_and_contents(
-    click_ctx, project, folder, sort, json, size, tree, usage, users, projects
+    click_ctx, project, folder, sort, json, size, tree, usage, binary, users, projects
 ):
     """List the projects you have access to or the project contents.
 
@@ -188,6 +199,7 @@ def list_projects_and_contents(
                 no_prompt=click_ctx.get("NO_PROMPT", False),
                 json=json,
                 token_path=click_ctx.get("TOKEN_PATH"),
+                binary=binary,
             ) as lister:
                 projects = lister.list_projects(sort_by=sort)
                 if json:

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -556,7 +556,7 @@ class DataLister(base.DDSBaseClass):
             title="Your Project(s)",
             show_header=True,
             header_style="bold",
-            show_footer=self.show_usage,
+            show_footer=self.show_usage and "Usage" in column_formatting,
             caption=(
                 "The cost is calculated from the pricing provided by Safespring (unit kr/GB/month) "
                 "and is therefore approximate. Contact the Data Centre for more details."

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -118,7 +118,6 @@ class DataLister(base.DDSBaseClass):
                     "%a, %d %b %Y %H:%M:%S %Z"
                 )
 
-        LOG.info(project_info)
         # Sort projects according to chosen or default, first ID
         sorted_projects = self.__sort_projects(projects=project_info, sort_by=sort_by)
 
@@ -566,10 +565,6 @@ class DataLister(base.DDSBaseClass):
                 overflow=colformat["overflow"],
             )
 
-        # # calculate the magnitudes for keeping the unit prefix constant across all projects
-        # magnitudes = dds_cli.utils.calculate_magnitude(sorted_projects, column_formatting.keys())
-
-        # print(magnitudes)
         # Add all column values for each row to table
         for proj in sorted_projects:
             table.add_row(

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -118,6 +118,7 @@ class DataLister(base.DDSBaseClass):
                     "%a, %d %b %Y %H:%M:%S %Z"
                 )
 
+        LOG.info(project_info)
         # Sort projects according to chosen or default, first ID
         sorted_projects = self.__sort_projects(projects=project_info, sort_by=sort_by)
 
@@ -565,14 +566,15 @@ class DataLister(base.DDSBaseClass):
                 overflow=colformat["overflow"],
             )
 
-        # calculate the magnitudes for keeping the unit prefix constant across all projects
-        magnitudes = dds_cli.utils.calculate_magnitude(sorted_projects, column_formatting.keys())
+        # # calculate the magnitudes for keeping the unit prefix constant across all projects
+        # magnitudes = dds_cli.utils.calculate_magnitude(sorted_projects, column_formatting.keys())
 
+        # print(magnitudes)
         # Add all column values for each row to table
         for proj in sorted_projects:
             table.add_row(
                 *[
-                    escape(dds_cli.utils.format_api_response(proj[i], i, magnitudes[i]))
+                    escape(dds_cli.utils.format_api_response(response=proj[i], key=i))
                     for i in column_formatting
                 ]
             )

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -181,7 +181,11 @@ class DataLister(base.DDSBaseClass):
         # Get max length of size string
         max_size = max(
             [
-                len(x["size"].split(" ")[0])
+                len(
+                    dds_cli.utils.format_api_response(
+                        response=x["size"], key="Size", binary=self.binary
+                    ).split(" ", maxsplit=1)[0]
+                )
                 for x in sorted_files_folders
                 if show_size and "size" in x
             ],
@@ -211,13 +215,16 @@ class DataLister(base.DDSBaseClass):
 
             # Add size to line if option specified
             if show_size and "size" in x:
-                line += f"{tab}{x['size'].split()[0]}"
+                size = dds_cli.utils.format_api_response(
+                    response=x["size"], key="Size", binary=self.binary
+                )
+                line += f"{tab}{size.split()[0]}"
 
                 # Define space between number and size format
                 tabs_bf_format = th.TextHandler.format_tabs(
-                    string_len=len(x["size"]), max_string_len=max_size, tab_len=2
+                    string_len=len(size), max_string_len=max_size, tab_len=2
                 )
-                line += f"{tabs_bf_format}{x['size'].split()[1]}"
+                line += f"{tabs_bf_format}{size.split()[1]}"
             tree.add(line)
 
         # Print output to stdout

--- a/dds_cli/data_lister.py
+++ b/dds_cli/data_lister.py
@@ -52,6 +52,7 @@ class DataLister(base.DDSBaseClass):
         no_prompt: bool = False,
         json: bool = False,
         token_path: str = None,
+        binary: bool = False,
     ):
         """Handle actions regarding data listing in the cli."""
         # Only method "ls" can use the DataLister class
@@ -71,6 +72,7 @@ class DataLister(base.DDSBaseClass):
         self.show_usage = show_usage
         self.tree = tree
         self.json = json
+        self.binary = binary
 
     # Public methods ########################### Public methods #
 
@@ -569,7 +571,11 @@ class DataLister(base.DDSBaseClass):
         for proj in sorted_projects:
             table.add_row(
                 *[
-                    escape(dds_cli.utils.format_api_response(response=proj[i], key=i))
+                    escape(
+                        dds_cli.utils.format_api_response(
+                            response=proj[i], key=i, binary=self.binary
+                        )
+                    )
                     for i in column_formatting
                 ]
             )

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -217,7 +217,7 @@ def format_api_response(response, key: str):
             if key == "Usage":
                 formatted_response += "H"
         elif key == "Cost":
-            formatted_response = "{:.1f}".format(response) if response >= 1.00 else str(0)
+            formatted_response = f"{response:.1f}" if response >= 1.00 else str(0) + " kr"
 
     return str(formatted_response)
 

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -206,7 +206,7 @@ def get_json_response(response):
     return json_response
 
 
-def format_api_response(response, key: str, binary: bool = False):
+def format_api_response(response, key: str, binary: bool = False, always_show: bool = False):
     """Take a value e.g. bytes and reformat it to include a unit prefix."""
     formatted_response = response
     if isinstance(response, bool):

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -26,7 +26,7 @@ stderr_console = rich.console.Console(stderr=True)
 class HumanBytes:
     """Format as human readable.
 
-    Partially copied from Stack Overflow: https://stackoverflow.com/a/63839503.
+    Copied from Stack Overflow: https://stackoverflow.com/a/63839503.
     """
 
     METRIC_LABELS: List[str] = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -12,12 +12,73 @@ from jwcrypto.jws import InvalidJWSObject
 from jwcrypto import jwt
 import http
 from rich.table import Table
+from typing import List, Union
 
 import dds_cli.exceptions
 from dds_cli import DDSEndpoint
 
 console = rich.console.Console()
 stderr_console = rich.console.Console(stderr=True)
+
+# Classes
+
+
+class HumanBytes:
+    """Format as human readable.
+
+    Partially copied from Stack Overflow: https://stackoverflow.com/a/63839503.
+    """
+
+    METRIC_LABELS: List[str] = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+    BINARY_LABELS: List[str] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+    PRECISION_OFFSETS: List[float] = [0.5, 0.05, 0.005, 0.0005]  # PREDEFINED FOR SPEED.
+    PRECISION_FORMATS: List[str] = [
+        "{}{:.0f} {}",
+        "{}{:.1f} {}",
+        "{}{:.2f} {}",
+        "{}{:.3f} {}",
+    ]  # PREDEFINED FOR SPEED.
+
+    @staticmethod
+    def format(num: Union[int, float], metric: bool = False, precision: int = 1) -> str:
+        """Human-readable formatting of bytes, using binary (powers of 1024)
+        or metric (powers of 1000) representation.
+        """
+        assert isinstance(num, (int, float)), "num must be an int or float"
+        assert isinstance(metric, bool), "metric must be a bool"
+        assert (
+            isinstance(precision, int) and precision >= 0 and precision <= 3
+        ), "precision must be an int (range 0-3)"
+
+        unit_labels = HumanBytes.METRIC_LABELS if metric else HumanBytes.BINARY_LABELS
+        last_label = unit_labels[-1]
+        unit_step = 1000 if metric else 1024
+        unit_step_thresh = unit_step - HumanBytes.PRECISION_OFFSETS[precision]
+
+        is_negative = num < 0
+        if is_negative:  # Faster than ternary assignment or always running abs().
+            num = abs(num)
+
+        for unit in unit_labels:
+            if num < unit_step_thresh:
+                # VERY IMPORTANT:
+                # Only accepts the CURRENT unit if we're BELOW the threshold where
+                # float rounding behavior would place us into the NEXT unit: F.ex.
+                # when rounding a float to 1 decimal, any number ">= 1023.95" will
+                # be rounded to "1024.0". Obviously we don't want ugly output such
+                # as "1024.0 KiB", since the proper term for that is "1.0 MiB".
+                break
+            if unit != last_label:
+                # We only shrink the number if we HAVEN'T reached the last unit.
+                # NOTE: These looped divisions accumulate floating point rounding
+                # errors, but each new division pushes the rounding errors further
+                # and further down in the decimals, so it doesn't matter at all.
+                num /= unit_step
+
+        return HumanBytes.PRECISION_FORMATS[precision].format("-" if is_negative else "", num, unit)
+
+
+# Functions
 
 
 def sort_items(items: list, sort_by: str) -> list:
@@ -145,106 +206,20 @@ def get_json_response(response):
     return json_response
 
 
-def calculate_magnitude(projects, keys, iec_standard=False):
-    """Calculate magnitude of values.
-
-    Uses the project list, obtains the values assigned to a particular key iteratively and
-    calculates the best magnitude to format this set of values consistently.
-    """
-    # initialize the dictionary to be returned
-    magnitudes = dict(zip(keys, [None] * len(keys)))
-
-    for key in keys:
-        values = [proj[key] for proj in projects]
-
-        if all(isinstance(x, numbers.Number) for x in values):
-
-            if key in ["Size", "Usage"] and iec_standard:
-                base = 1024.0
-            else:
-                base = 1000.0
-
-            # exclude values smaller than base, such that empty projects don't interfer with
-            # the calculation ensures that a minimum can be calculated if no val is larger than base
-            minimum = (lambda x: min(x) if x else 1)([val for val in values if val >= base])
-            mag = 0
-
-            while abs(minimum) >= base:
-                mag += 1
-                minimum /= base
-
-            magnitudes[key] = mag
-    return magnitudes
-
-
-def format_api_response(response, key, magnitude=None, iec_standard=False):
+def format_api_response(response, key: str):
     """Take a value e.g. bytes and reformat it to include a unit prefix."""
-    if isinstance(response, str):
-        return response  # pass the response if already a string
-
+    formatted_response = response
     if isinstance(response, bool):
-        return ":white_heavy_check_mark:" if response else ":x:"
-
-    if isinstance(response, numbers.Number):
-        response = float(f"{response:.3g}")
-        mag = 0
-
+        formatted_response = ":white_heavy_check_mark:" if response else ":x:"
+    elif isinstance(response, numbers.Number):
         if key in ["Size", "Usage"]:
-            if iec_standard:
-                # The IEC created prefixes such as kibi, mebi, gibi, etc.,
-                # to unambiguously denote powers of 1024
-                prefixlist = ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"]
-                base = 1024.0
-            else:
-                prefixlist = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"]
-                base = 1000.0
-            spacer_a = " "
-            spacer_b = ""
-        else:
-            # Default to the prefixes of the International System of Units (SI)
-            prefixlist = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"]
-            base = 1000.0
-            spacer_a = ""
-            spacer_b = " "
-
-        if not magnitude:
-            # calculate a suitable magnitude if not given
-            while abs(response) >= base:
-                mag += 1
-                response /= base
-        else:
-            # utilize the given magnitude
-            response /= base**magnitude
-
-        if key == "Size":
-            unit = "B"  # lock
-        elif key == "Usage":
-            unit = "Bh"  # arrow up
+            formatted_response = HumanBytes.format(num=response, metric=True)
+            if key == "Usage":
+                formatted_response += "H"
         elif key == "Cost":
-            unit = "SEK"
-            prefixlist[1] = "K"  # for currencies, the capital K is more common.
-            prefixlist[3] = "B"  # for currencies, Billions are used instead of Giga
+            formatted_response = "{:.1f}".format(response) if response >= 1.00 else str(0)
 
-        if response > 0:
-            # if magnitude was given, then use fixed number of digits
-            # to allow for easier comparisons across projects
-            if magnitude:
-                return "{}{}{}".format(
-                    f"{response:.2f}",
-                    spacer_a,
-                    prefixlist[magnitude] + spacer_b + unit,
-                )
-            else:  # if values are anyway prefixed individually, then strip trailing 0 for readability
-                return "{}{}{}".format(
-                    f"{response:.2f}".rstrip("0").rstrip("."),
-                    spacer_a,
-                    prefixlist[mag] + spacer_b + unit,
-                )
-        else:
-            return f"0 {unit}"
-    else:
-        # Since table.add.row() expects a string, try to return whatever is not yet a string but also not numeric as string
-        return str(response)
+    return str(formatted_response)
 
 
 def get_token_header_contents(token):

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -212,18 +212,17 @@ def format_api_response(response, key: str):
     if isinstance(response, bool):
         formatted_response = ":white_heavy_check_mark:" if response else ":x:"
     elif isinstance(response, numbers.Number):
-        if key in ["Size", "Usage"]:
+        if key in ["Size", "Usage", "Cost"]:
             formatted_response = HumanBytes.format(num=response, metric=True)
             if key == "Usage":
                 formatted_response += "H"
-        elif key == "Cost":
-            formatted_response = f"{response:.1f}" if response >= 1.00 else str(0) + " kr"
-
+            elif key == "Cost":
+                formatted_response = formatted_response[0:-1] + "kr"
     return str(formatted_response)
 
 
 def get_token_header_contents(token):
-    """Function to extract the jose header of the DDS token (JWE)
+    """Function to extract the jose header of the DDS token (JWE).
 
     :param token: a token that is not None
 

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -206,18 +206,19 @@ def get_json_response(response):
     return json_response
 
 
-def format_api_response(response, key: str):
+def format_api_response(response, key: str, binary: bool = False):
     """Take a value e.g. bytes and reformat it to include a unit prefix."""
     formatted_response = response
     if isinstance(response, bool):
         formatted_response = ":white_heavy_check_mark:" if response else ":x:"
     elif isinstance(response, numbers.Number):
-        if key in ["Size", "Usage", "Cost"]:
-            formatted_response = HumanBytes.format(num=response, metric=True)
+        if key in ["Size", "Usage"]:
+            formatted_response = HumanBytes.format(num=response, metric=not binary)
             if key == "Usage":
                 formatted_response += "H"
-            elif key == "Cost":
-                formatted_response = formatted_response[0:-1] + "kr"
+        elif key == "Cost":
+            formatted_response = HumanBytes.format(num=response, metric=True)[0:-1] + "kr"
+
     return str(formatted_response)
 
 


### PR DESCRIPTION
Currently the project listing functionality does not display the project sizes, usage and costs like I want them to. 
The default should be to display them in the exact form, not a common unit prefix and not any automatic recognition of the numbers. 

In the future, after getting the DDS into production, we can improve on this and add additional options like @MatthiasZepper has done in https://github.com/ScilifelabDataCentre/dds_cli/pull/377 for example. This however should not change the default that I explained above. 

This PR also fixes the bug where the size is not shown for the Researchusers. 

Before submitting a PR to the `dev` branch:
- [ ] Tests passing
- [ ] Black formatting
- [ ] Rebase/merge the `dev` branch
- [ ] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `setup.py` (?) 