### PR TITLE
Better error message if there are no unit users

### DIFF
--- a/dds_cli/account_manager.py
+++ b/dds_cli/account_manager.py
@@ -389,6 +389,10 @@ class AccountManager(dds_cli.base.DDSBaseClass):
             error_message="Failed getting unit users from API",
         )
 
+        if response.get("empty"):
+            LOG.info(f"There are no Unit Admins or Unit Personnel connected to unit '{unit}'")
+            return
+
         users, keys, unit = dds_cli.utils.get_required_in_response(
             keys=["users", "keys", "unit"], response=response
         )

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -136,7 +136,7 @@ def get_required_in_response(keys: list, response: dict) -> tuple:
 
     if not_returned:
         raise dds_cli.exceptions.ApiResponseError(
-            message=f"The following information was returned: {not_returned}"
+            message=f"The following information was not returned: {not_returned}"
         )
 
     return tuple(response.get(x) for x in keys)


### PR DESCRIPTION
Before submitting a PR to the `dev` branch:
- [x] Tests passing
- [x] Black formatting
- [x] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG

Additional checks before submitting a PR to the `master` branch:
- Change version in `dds_cli/version.py` (?) 