### PR TITLE
Display multiple motds and deactivate old ones

### DIFF
--- a/dds_cli/__init__.py
+++ b/dds_cli/__init__.py
@@ -120,8 +120,8 @@ class DDSEndpoint:
     # Project status updation
     UPDATE_PROJ_STATUS = BASE_ENDPOINT + "/proj/status"
 
-    # Adding new MOTD
-    ADD_NEW_MOTD = BASE_ENDPOINT + "/motd"
+    # MOTD management
+    MOTD = BASE_ENDPOINT + "/motd"
 
     TIMEOUT = 30
 

--- a/dds_cli/__init__.py
+++ b/dds_cli/__init__.py
@@ -99,6 +99,7 @@ class DDSEndpoint:
     LIST_PROJ_USERS = BASE_ENDPOINT + "/proj/users"
     LIST_UNITS_ALL = BASE_ENDPOINT + "/unit/info/all"
     LIST_UNIT_USERS = BASE_ENDPOINT + "/unit/users"
+    LIST_ACTIVE_MOTDS = BASE_ENDPOINT + "/motd/active"
 
     # Deleting urls
     REMOVE_PROJ_CONT = BASE_ENDPOINT + "/proj/rm"
@@ -120,7 +121,7 @@ class DDSEndpoint:
     UPDATE_PROJ_STATUS = BASE_ENDPOINT + "/proj/status"
 
     # Adding new MOTD
-    ADD_NEW_MOTD = BASE_ENDPOINT + "/unit/motd"
+    ADD_NEW_MOTD = BASE_ENDPOINT + "/motd"
 
     TIMEOUT = 30
 

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -1729,3 +1729,33 @@ def add_new_motd(click_ctx, message):
     ) as err:
         LOG.error(err)
         sys.exit(1)
+
+# -- dds motd ls -- #
+@motd_group_command.command(name="ls", no_args_is_help=False)
+@click.pass_obj
+def list_active_motds(click_ctx):
+    """List all active MOTDs."""
+    try:
+        with dds_cli.motd_manager.MotdManager(
+            no_prompt=click_ctx.get("NO_PROMPT", False),
+            token_path=click_ctx.get("TOKEN_PATH"),
+        ) as lister:
+            lister.list_all_active_motds()
+    except (
+        dds_cli.exceptions.AuthenticationError,
+        dds_cli.exceptions.ApiResponseError,
+        dds_cli.exceptions.ApiRequestError,
+        dds_cli.exceptions.DDSCLIException,
+    ) as err:
+        LOG.error(err)
+        sys.exit(1)
+
+# -- dds motd deactivate-- #
+@motd_group_command.command(name="deactivate")
+@click.option("--motd", type=int, required=True)
+@click.pass_obj
+def deactivate_motd(click_ctx, motd):
+    """Deactivate Message Of The Day.
+
+    Only usable by Super Admins.
+    """

--- a/dds_cli/motd_manager.py
+++ b/dds_cli/motd_manager.py
@@ -71,3 +71,37 @@ class MotdManager(dds_cli.base.DDSBaseClass):
         )
 
         LOG.info("A new MOTD was added to the database")
+
+    def list_all_active_motds(self):
+        """Get all active MOTDs."""
+        response, _ = dds_cli.utils.perform_request(
+            endpoint=dds_cli.DDSEndpoint.LIST_ACTIVE_MOTDS,
+            method="get",
+            headers=self.token,
+            error_message="Failed getting MOTDs from API",
+        )
+
+        # Get items from response
+        motd = response.get("motds")
+        if motd:
+            motds, keys = dds_cli.utils.get_required_in_response(
+                keys=["motds", "keys"], response=response
+            )
+        else:
+            LOG.info("No active Message Of The Day found")
+            exit()
+
+        # Sort the active MOTDs according to date created
+        motds = dds_cli.utils.sort_items(items=motds, sort_by="Created")
+
+        # Create table
+        table = dds_cli.utils.create_table(
+            title="Active MOTDs.",
+            columns=keys,
+            rows=motds,
+            ints_as_string=True,
+            caption="Active MOTDs.",
+        )
+
+        # Print out table
+        dds_cli.utils.print_or_page(item=table)

--- a/dds_cli/motd_manager.py
+++ b/dds_cli/motd_manager.py
@@ -63,7 +63,7 @@ class MotdManager(dds_cli.base.DDSBaseClass):
     def add_new_motd(self, message):
         """Add a new motd."""
         response_json, _ = dds_cli.utils.perform_request(
-            endpoint=DDSEndpoint.ADD_NEW_MOTD,
+            endpoint=DDSEndpoint.MOTD,
             headers=self.token,
             method="post",
             json={"message": message},
@@ -75,7 +75,7 @@ class MotdManager(dds_cli.base.DDSBaseClass):
     def list_all_active_motds(self):
         """Get all active MOTDs."""
         response, _ = dds_cli.utils.perform_request(
-            endpoint=dds_cli.DDSEndpoint.LIST_ACTIVE_MOTDS,
+            endpoint=dds_cli.DDSEndpoint.MOTD,
             method="get",
             headers=self.token,
             error_message="Failed getting MOTDs from API",
@@ -105,3 +105,15 @@ class MotdManager(dds_cli.base.DDSBaseClass):
 
         # Print out table
         dds_cli.utils.print_or_page(item=table)
+
+    def deactivate_motd(self, motd_id):
+        """Deactivate specific MOTD."""
+        response_json, _ = dds_cli.utils.perform_request(
+            endpoint=DDSEndpoint.MOTD,
+            headers=self.token,
+            method="put",
+            json={"motd_id": motd_id},
+            error_message="Failed deactivating the MOTD",
+        )
+
+        LOG.info(f"MOTD #{motd_id} was successfully deactivated")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -424,10 +424,10 @@ def test_perform_request_add_motd_error_insufficient_credentials() -> None:
         "email": "",
     }
     with Mocker() as mock:
-        mock.post(DDSEndpoint.ADD_NEW_MOTD, status_code=403, json=response_json)
+        mock.post(DDSEndpoint.MOTD, status_code=403, json=response_json)
         with raises(DDSCLIException) as exc_info:
             _: tuple(Response, str) = perform_request(
-                endpoint=DDSEndpoint.ADD_NEW_MOTD, headers={}, method="post"
+                endpoint=DDSEndpoint.MOTD, headers={}, method="post"
             )
 
         assert len(exc_info.value.args) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -320,22 +320,6 @@ def test_perform_request_request_exception() -> None:
     assert exc_info.value.args[0] == "API Request failed.: The database seems to be down."
 
 
-def test_perform_request_json_decode_error() -> None:
-    """Parse json from string"""
-    url: str = "http://localhost"
-    with Mocker() as mock:
-        mock.get(url, status_code=200, text="str")
-        with raises(ApiResponseError) as exc_info:
-            perform_request(
-                endpoint=url,
-                headers={},
-                method="get",
-            )
-
-        assert len(exc_info.value.args) == 1
-        assert exc_info.value.args[0] == "[Errno Expecting value] str: 0"
-
-
 def test_perform_request_api_response_error_internal_server_error() -> None:
     url: str = "http://localhost"
     response_json: Dict = {


### PR DESCRIPTION
Added functionality for working with MOTD as superadmin: display active ones and deactivate. 
Works with https://github.com/ScilifelabDataCentre/dds_web/pull/1199


Please include the following in this section

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [x] Any dependencies that are required for this change

Fixes #DDS-1305

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Rebase/merge the branch which this PR is made to
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_cli/version.py)

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [ ] The code follows the style guidelines of this project: Black / Prettier formatting
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
