### PR TITLE
Bug: Check that response_json is a dict before getting items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,3 +166,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 
 - Display message of the day at top before output ([#498](https://github.com/ScilifelabDataCentre/dds_cli/pull/498))
 - Change token check message for Windows to more user friendly ([#500](https://github.com/ScilifelabDataCentre/dds_cli/pull/500))
+- Bug: Add check for correct response format before getting items from it ([#503](https://github.com/ScilifelabDataCentre/dds_cli/pull/503))


### PR DESCRIPTION
# Description

When the API does not return a dict, the CLI crashes due to the `response_json.get` parts so I've added an additional check for this and replaced all occurrences of `response_json.get("message")` with `response_message` which is collected once instead.

- [ ] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_cli/version.py)

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
