### PR TITLE
Link to dev instance added to allow testing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,3 +168,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Change token check message for Windows to more user friendly ([#500](https://github.com/ScilifelabDataCentre/dds_cli/pull/500))
 - New command: List all users as Super Admin and find existing users ([#504](https://github.com/ScilifelabDataCentre/dds_cli/pull/504))
 - Add possibility of allowing group access to authenticated session ([#502](https://github.com/ScilifelabDataCentre/dds_cli/pull/502))
+
+## Summer 2022
+
+- Check for DDS_CLI_ENV = "test-instance" in order to allow testing of features before production ([#506](https://github.com/ScilifelabDataCentre/dds_cli/pull/506))

--- a/dds_cli/__init__.py
+++ b/dds_cli/__init__.py
@@ -59,10 +59,13 @@ class DDSEndpoint:
     BASE_ENDPOINT_LOCAL = "http://127.0.0.1:5000/api/v1"
     BASE_ENDPOINT_DOCKER = "http://dds_backend:5000/api/v1"
     BASE_ENDPOINT_REMOTE = "https://delivery.scilifelab.se/api/v1"
+    BASE_ENDPOINT_REMOTE_TEST = "https://dds-dev.dckube.scilifelab.se/api/v1"
     if os.getenv("DDS_CLI_ENV") == "development":
         BASE_ENDPOINT = BASE_ENDPOINT_LOCAL
     elif os.getenv("DDS_CLI_ENV") == "docker-dev":
         BASE_ENDPOINT = BASE_ENDPOINT_DOCKER
+    elif os.getenv("DDS_CLI_ENV") == "test-instance":
+        BASE_ENDPOINT = BASE_ENDPOINT_REMOTE_TEST
     else:
         BASE_ENDPOINT = BASE_ENDPOINT_REMOTE
 

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -91,8 +91,6 @@ dds_cli.utils.stderr_console.print(
     highlight=False,
 )
 
-dds_cli.utils.stderr_console.print(f"--- Instance: {dds_cli.DDSEndpoint.BASE_ENDPOINT}")
-
 motd = dds_cli.motd_manager.MotdManager.get_latest_motd()
 if motd:
     dds_cli.utils.stderr_console.print(f"[bold]Important information:[/bold] {motd} \n")

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -91,6 +91,8 @@ dds_cli.utils.stderr_console.print(
     highlight=False,
 )
 
+dds_cli.utils.stderr_console.print(f"--- Instance: {dds_cli.DDSEndpoint.BASE_ENDPOINT}")
+
 motd = dds_cli.motd_manager.MotdManager.get_latest_motd()
 if motd:
     dds_cli.utils.stderr_console.print(f"[bold]Important information:[/bold] {motd} \n")


### PR DESCRIPTION
# Description

To allow us (and possibly users) to test the DDS without having access to the production version, e.g. before signing up or in the case of a new feature, I added the dev instance link and a check for "test-instance". 

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [x] Any dependencies that are required for this change

Fixes X

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
