### PR TITLE
Add spinner when getting project private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,3 +173,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 
 - Check for DDS_CLI_ENV = "test-instance" in order to allow testing of features before production ([#506](https://github.com/ScilifelabDataCentre/dds_cli/pull/506))
 - List all active motds instead of latest and new command for deactivating motds ([#505](https://github.com/ScilifelabDataCentre/dds_cli/pull/505))
+- New spinner when getting project private ([#510](https://github.com/ScilifelabDataCentre/dds_cli/pull/510))

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -11,7 +11,9 @@ import pathlib
 
 # Installed
 import http
+import time
 import simplejson
+from rich.progress import Progress, SpinnerColumn
 
 # Own modules
 import dds_cli.directory
@@ -141,7 +143,23 @@ class DDSBaseClass:
         public = self.__get_key()
 
         # Project private only required for get
-        private = self.__get_key(private=True) if self.method == "get" else None
+        private = None
+        if self.method == "get":
+            # Key derivation on server is slow - display spinner
+            information_to_user = "Preparing for download. This may be slow. Please wait..."
+            with Progress(
+                SpinnerColumn(spinner_name="dots12", style="blue"),
+                "{task.description}",
+                console=dds_cli.utils.stderr_console,
+            ) as spinner:
+                # Start spinner
+                task = spinner.add_task(description=information_to_user)
+                try:
+                    # Get key
+                    private = self.__get_key(private=True)
+                finally:
+                    # Always remove spinner
+                    spinner.remove_task(task)
 
         return private, public
 


### PR DESCRIPTION
# Description

Due to key derivation issue. It currently looks like the DDS freezes. 

Add a message inform users that the DDS is working and that it's not frozen so that they know it can take some time before the download starts

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes DDS-1315

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_cli/version.py)

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
