### PR TITLE
Fixes an error when dds is run without any parameter

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -91,7 +91,7 @@ dds_cli.utils.stderr_console.print(
     highlight=False,
 )
 
-if len(sys.argv) > 1 and sys.argv[1] != "motd":
+if len(sys.argv) == 1 or (len(sys.argv) > 1 and sys.argv[1] != "motd"):
     motds = dds_cli.motd_manager.MotdManager.list_all_active_motds(table=False)
     if motds:
         dds_cli.utils.stderr_console.print(f"[bold]Important information:[/bold]")

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -91,7 +91,7 @@ dds_cli.utils.stderr_console.print(
     highlight=False,
 )
 
-if "motd" not in sys.argv:
+if len(sys.argv) > 1 and sys.argv[1] != "motd":
     motds = dds_cli.motd_manager.MotdManager.list_all_active_motds(table=False)
     if motds:
         dds_cli.utils.stderr_console.print(f"[bold]Important information:[/bold]")

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -91,7 +91,7 @@ dds_cli.utils.stderr_console.print(
     highlight=False,
 )
 
-if sys.argv[1] != "motd":
+if "motd" not in sys.argv:
     motds = dds_cli.motd_manager.MotdManager.list_all_active_motds(table=False)
     if motds:
         dds_cli.utils.stderr_console.print(f"[bold]Important information:[/bold]")


### PR DESCRIPTION
# Description
When the dds command is run without any parameters it returned the following:
```
valge939@BMC-3P9KJ2DHP dds_cli % dds     
     ︵ 
 ︵ (  )   ︵ 
(  ) ) (  (  )   SciLifeLab Data Delivery System 
 ︶  (  ) ) (    https://delivery.scilifelab.se/ 
      ︶ (  )    Version 1.0.73 
          ︶
Traceback (most recent call last):
  File "/Users/valge939/.pyenv/versions/3.9.13/bin/dds", line 5, in <module>
    from dds_cli.__main__ import dds_main
  File "/Users/valge939/scilifelab_dc/dds_cli/dds_cli/__main__.py", line 95, in <module>
    if sys.argv[1] != "motd":
IndexError: list index out of range

```

Please include the following in this section

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [x] Any dependencies that are required for this change

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Rebase/merge the branch which this PR is made to
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_cli/version.py)
- [ ] I am bumping the major version (e.g. 1.x.x to 2.x.x) and I have made the corresponding changes to the API version

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [ ] The code follows the style guidelines of this project: Black / Prettier formatting
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
