### PR TITLE
Set project as busy when starting deletion and not busy when done (3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,4 +182,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 ## Sprint (2022-09-02 - 2022-09-16)
 
 - Add storage usage information in the Units listing table for Super Admin ([#523](https://github.com/ScilifelabDataCentre/dds_cli/pull/523))
-- Set project as busy / not busy when starting / finishing a deletion ([#526](https://github.com/ScilifelabDataCentre/dds_cli/pull/527))
+- Set project as busy / not busy when starting / finishing a deletion ([#527](https://github.com/ScilifelabDataCentre/dds_cli/pull/527))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,4 +182,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 ## Sprint (2022-09-02 - 2022-09-16)
 
 - Add storage usage information in the Units listing table for Super Admin ([#523](https://github.com/ScilifelabDataCentre/dds_cli/pull/523))
-- Set project as busy / not busy when starting / finishing an upload ([#525](https://github.com/ScilifelabDataCentre/dds_cli/pull/525))
+- Set project as busy / not busy when starting / finishing a deletion ([#526](https://github.com/ScilifelabDataCentre/dds_cli/pull/527))

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -126,9 +126,10 @@ class DDSBaseClass:
 
         This is not entered if there's an error during __init__.
         """
-        if self.method in ["put", "get"]:
+        if self.method in ["put", "get", "rm"]:
             self.cleanup_busy_status()
-            self.__printout_delivery_summary()
+            if self.method != "rm":
+                self.__printout_delivery_summary()
 
         # Exception is not handled
         if exc_type is not None:

--- a/dds_cli/data_remover.py
+++ b/dds_cli/data_remover.py
@@ -60,6 +60,8 @@ class DataRemover(base.DDSBaseClass):
                 attempted_method=method, message="DataRemover attempting unauthorized method"
             )
 
+        self.set_as_busy()
+
     def __create_failed_table(self, resp_json, level="File"):
         """Output a response after deletion."""
         # Check that enough info


### PR DESCRIPTION
# Description

This is an add-on to https://github.com/ScilifelabDataCentre/dds_cli/pull/525 - some refactoring.

Merge 525 first and then rebase this. 

Should be tested with https://github.com/ScilifelabDataCentre/dds_web/pull/1266 

- [ ] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes DDS-1333

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_cli/version.py)
- [ ] I am bumping the major version (e.g. 1.x.x to 2.x.x) and I have made the corresponding changes to the API version

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
