### PR TITLE
Publish to TestPyPi on PR and release 

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -42,7 +42,6 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           skip_existing: true
-      
 
   ddsclibinaries:
     name: Build binary packages for the DDS CLI

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -25,6 +25,15 @@ jobs:
       - name: Build the distribution
         run: python setup.py sdist bdist_wheel
 
+      - name: Publish dist to TestPyPI
+        if: github.repository == 'ScilifelabDataCentre/dds_cli'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print_hash: true
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
       - name: Publish dist to PyPI
         if: github.repository == 'ScilifelabDataCentre/dds_cli'
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -33,6 +42,7 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           skip_existing: true
+      
 
   ddsclibinaries:
     name: Build binary packages for the DDS CLI

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -29,6 +29,7 @@ jobs:
         if: github.repository == 'ScilifelabDataCentre/dds_cli'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          print_hash: true
           user: __token__
           password: ${{ secrets.pypi_password }}
           skip_existing: true

--- a/.github/workflows/test-pypi-cli.yml
+++ b/.github/workflows/test-pypi-cli.yml
@@ -1,7 +1,5 @@
 name: Publish CLI to TestPyPi
 on:
-  push:
-    branches: [dev, master]
   pull_request:
     branches: [dev]
 jobs:

--- a/.github/workflows/test-pypi-cli.yml
+++ b/.github/workflows/test-pypi-cli.yml
@@ -1,0 +1,35 @@
+name: Publish CLI to TestPyPi
+on:
+  push: 
+    branches: [dev, master]
+  pull_request:
+    branches: [dev]
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out source-code repository
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install .
+
+      - name: Build the distribution
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish dist to TestPyPI
+        if: github.repository == 'ScilifelabDataCentre/dds_cli'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print_hash: true
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true

--- a/.github/workflows/test-pypi-cli.yml
+++ b/.github/workflows/test-pypi-cli.yml
@@ -1,6 +1,6 @@
 name: Publish CLI to TestPyPi
 on:
-  push: 
+  push:
     branches: [dev, master]
   pull_request:
     branches: [dev]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,3 +226,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 # Sprint (2023-01-09 - 2023-01-20)
 
 - Workflow: Scan with Trivy on PR and schedule ([#591](https://github.com/ScilifelabDataCentre/dds_cli/pull/591))
+- Workflow: Publish to TestPyPi on PR and release ([#592](https://github.com/ScilifelabDataCentre/dds_cli/pull/592))


### PR DESCRIPTION
> **Before submitting the PR**
>
> - Fill in and tick fields
> - _Remove all rows_ that are not relevant for the current PR
>   - Revelant option missing? Add it as an item and add a PR comment informing that the new option should be included into this template.
>
> **All _relevant_ items should be ticked before the PR is merged**

# Description

- [x] Summary of the changes and the related issue: 

In order to debug and prevent potential issues during releases, we should also 1. publish the CLI to TestPyPi on pr to dev and on release before real publishing, 2. make sure that the hashes are correct. Possible that we also should recommend verifying the hashes after installation. 

The `print_hash: true` part in tells the action to show the hashes of what will be published. Easily verified manually by checking on PyPi. If something happens though and there's an error, the publishing will not occur. 

- Fixes an issue in GitHub / Jira:
  - [x] Yes: DDS-1443

## Type of change

- [x] Workflow

# Checklist:

## General

- [x] [Changelog](../CHANGELOG.md): New row added. Not needed when PR includes _only_ tests.

## Repository / Releases

- [x] Rebase / update of branch done

## Checks

- [x] CodeQL passes
- [x] Formatting: Black & Prettier checks pass
- Tests
  - [x] The tests pass
- Trivy:
  - [x] There are no new security alerts

