### PR TITLE
Catch UnicodeEncodeError in case of non-latin 1 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,3 +246,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 
 - Bug: Return error code 1 if error during upload ([#615](https://github.com/ScilifelabDataCentre/dds_cli/pull/615))
 - Clarification: Users should check that the error-file has been generated, and keep it in case we need it for debugging purposes ([#616](https://github.com/ScilifelabDataCentre/dds_cli/pull/616))
+- Bug: Catch UnicodeEncodeError during API request to avoid unclear error message upon usage of non-latin1 characters in username and password ([#617](https://github.com/ScilifelabDataCentre/dds_cli/pull/617))

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -106,7 +106,7 @@ class User:
             raise exceptions.AuthenticationError(
                 message="Non-empty password needed to be able to authenticate."
             )
-        
+
         try:
             response_json, _ = dds_cli.utils.perform_request(
                 dds_cli.DDSEndpoint.ENCRYPTED_TOKEN,
@@ -118,7 +118,7 @@ class User:
             raise dds_cli.exceptions.ApiRequestError(
                 message="The entered username or password seems to contain invalid characters. Please try again."
             )
-    
+
         # Token received from API needs to be completed with a mfa timestamp
         partial_auth_token = response_json.get("token")
         secondfactor_method = response_json.get("secondfactor_method")

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -106,14 +106,19 @@ class User:
             raise exceptions.AuthenticationError(
                 message="Non-empty password needed to be able to authenticate."
             )
-
-        response_json, _ = dds_cli.utils.perform_request(
-            dds_cli.DDSEndpoint.ENCRYPTED_TOKEN,
-            method="get",
-            auth=(username, password),
-            error_message="Failed to authenticate user",
-        )
-
+        
+        try:
+            response_json, _ = dds_cli.utils.perform_request(
+                dds_cli.DDSEndpoint.ENCRYPTED_TOKEN,
+                method="get",
+                auth=(username, password),
+                error_message="Failed to authenticate user",
+            )
+        except UnicodeEncodeError as err:
+            raise dds_cli.exceptions.ApiRequestError(
+                message="The entered username or password seems to contain invalid characters. Please try again."
+            )
+    
         # Token received from API needs to be completed with a mfa timestamp
         partial_auth_token = response_json.get("token")
         secondfactor_method = response_json.get("secondfactor_method")

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -110,7 +110,7 @@ class User:
         response_json, _ = dds_cli.utils.perform_request(
             dds_cli.DDSEndpoint.ENCRYPTED_TOKEN,
             method="get",
-            auth=(username, password),
+            auth=(username, password.encode("utf-8")),
             error_message="Failed to authenticate user",
         )
 

--- a/dds_cli/user.py
+++ b/dds_cli/user.py
@@ -110,7 +110,7 @@ class User:
         response_json, _ = dds_cli.utils.perform_request(
             dds_cli.DDSEndpoint.ENCRYPTED_TOKEN,
             method="get",
-            auth=(username, password.encode("utf-8")),
+            auth=(username, password),
             error_message="Failed to authenticate user",
         )
 

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -189,7 +189,9 @@ def perform_request(
         )
         response_json = response.json()
     except UnicodeEncodeError as err:
-        raise dds_cli.exceptions.ApiRequestError(message=f"The entered username or password seems to contain invalid characters. Please try again.")
+        raise dds_cli.exceptions.ApiRequestError(
+            message=f"The entered username or password seems to contain invalid characters. Please try again."
+        )
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(message=str(err))
     except requests.exceptions.RequestException as err:

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -190,7 +190,7 @@ def perform_request(
         response_json = response.json()
     except UnicodeEncodeError as err:
         raise dds_cli.exceptions.ApiRequestError(
-            message=f"The entered username or password seems to contain invalid characters. Please try again."
+            message="The entered username or password seems to contain invalid characters. Please try again."
         )
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(message=str(err))

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -188,6 +188,8 @@ def perform_request(
             timeout=timeout,
         )
         response_json = response.json()
+    except UnicodeEncodeError as err:
+        raise dds_cli.exceptions.ApiRequestError(message=f"The entered username or password seems to contain invalid characters. Please try again.")
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(message=str(err))
     except requests.exceptions.RequestException as err:

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -188,10 +188,6 @@ def perform_request(
             timeout=timeout,
         )
         response_json = response.json()
-    except UnicodeEncodeError as err:
-        raise dds_cli.exceptions.ApiRequestError(
-            message="The entered username or password seems to contain invalid characters. Please try again."
-        )
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(message=str(err))
     except requests.exceptions.RequestException as err:


### PR DESCRIPTION
<!--
> **Before _submitting_ PR:**
>
> - Fill in and tick fields
> - _Remove all rows_ that are not relevant for the current PR
>   - Revelant option missing? Add it as an item and add a PR comment informing that the new option should be included into this template.
>
> **Before _merging_ PR:**
>
> _Tick all relevant items._
-->

## **1. This PR contains the following changes...**

A user reported that they had used a specific special character in the password and that the CLI was giving a UnicodeEncodeError when trying to log in. Turns out that this is a `requests` issue and has been reported quite a lot, but it'd not something they'll be fixing. 

This snippet is what causes the error: 
https://github.com/psf/requests/blob/7f694b79e114c06fac5ec06019cada5a61e5570f/requests/auth.py#L59-L60 

To avoid this, we're catching the error, and (in the web) adding a check for that the username and password only contain characters that are latin1 encodable.

https://github.com/ScilifelabDataCentre/dds_web/pull/1402

## **2. The following additional changes are required for this to work**

_X_

## **3. The PR fixes the following GitHub issue / Jira task**

<!-- Comment out the item which does not apply here.-->

- [ ] GitHub issue (link):
- [x] Jira task (ID, `DDS-xxxx`): DDS-1489
- [ ] The PR does not fix a specific GitHub issue or Jira task

## **4. What _type of change(s)_ does the PR contain?**

<!--
- "Breaking": The change will cause existing functionality to not work as expected.
- Workflow: E.g. a new github action or changes to this PR template. Anything that alters our or the codes workflow.
-->

- [ ] New feature
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [ ] Non-breaking
- [x] Bug fix
  - [ ] Breaking: _X_
  - [x] Non-breaking: If a user has used a non-latin1 character in password, they'll have to change it. Username should not be possible to have these characters in, this is just in case such a character is passed in during auth, e.g. by mistake.
- [ ] Security Alert fix
- [ ] Documentation
- [ ] Tests **(only)**
- [ ] Workflow

## **5. Checklist**

<!-- Comment out the items which do not apply here.-->

### **Always**

<!-- Always go through the following items. -->

- [Changelog](../CHANGELOG.md)
  - [x] Added
  - [ ] Not needed (E.g. PR contains _only_ tests)
- Rebase / Update / Merge _from_ base branch (the branch from which the current is forked)
  - [x] Done
  - [ ] Not needed
- Blocking PRs
  - [ ] Merged
  - [x] No blocking PRs
- PR to `master` branch
  - [ ] Yes: Go to the section [PR to master](#pr-to-master)
  - [x] No

### If PR consists of **code change(s)**

<!-- If the PR contains code changes, the following need to be checked.-->

- Self review
  - [x] Done
- Comments, docstrings, etc
  - [x] Added / Updated
- Documentation
  - [ ] Updated
  - [x] Update not needed

<!-- 
### If PR is to **master**
-->
<!-- Is your PR to the master branch? The following items need to be checked off. -->
<!--
- [ ] I have followed steps 1-5 in [the release instructions](../docs/procedures/new_release.md)
- [ ] I am bumping the major version (e.g. 1.x.x to 2.x.x)
- [ ] I have made the corresponding changes to the web/API version

**Is this version _backward compatible?_**

- [ ] Yes: The code works together with `dds_web/master` branch
- [ ] No: The code **does not** entirely / at all work together with the `dds_web/master` branch. _Please add detailed and clear information about the broken features_
-->

## **6. Actions / Scans**

<!-- Go through all checkboxes. All actions must pass before merging is allowed.-->

- **Black**: Python code formatter. Does not execute. Only tests.
  Run `black .` locally to execute formatting.
  - [x] Passed
- **Prettier**: General code formatter. Our use case: MD and yaml mainly.
  Run `npx prettier --write .` locally to execute formatting.
  - [x] Passed
- **Yamllint**: Linting of yaml files.
  - [x] Passed
- **Tests**: Pytest to verify that functionality works as expected.
  - [ ] New tests added
  - [x] No new tests
  - [x] Passed
- **TestPyPi**: Build CLI and publish to TestPyPi in order to verify before release.
  - [x] Passed
- **CodeQL**: Scan for security vulnerabilities, bugs, errors
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Trivy**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Snyk**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
