### PR TITLE
Return understandable message when response doesn't contain json

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -279,4 +279,4 @@ _Nothing merged in CLI during this sprint_
 
 # 2023-06-26 - 2023-08-04
 
-- Print understandable message when request times out and / or doesn't contain json ([#638](https://github.com/ScilifelabDataCentre/dds_cli/pull/638))
+- Print understandable message when request response doesn't contain json ([#638](https://github.com/ScilifelabDataCentre/dds_cli/pull/638))

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -276,3 +276,7 @@ _Nothing merged in CLI during this sprint_
 
 - Url to testing instance updated after move to new cluster ([#631](https://github.com/ScilifelabDataCentre/dds_cli/pull/631))
 - Dependency: Bump `cryptography` due to CVE-2023-0286 and dependabot ([#635](https://github.com/ScilifelabDataCentre/dds_cli/pull/635))
+
+# 2023-06-26 - 2023-08-04
+
+- Print understandable message when request times out and / or doesn't contain json ([#638](https://github.com/ScilifelabDataCentre/dds_cli/pull/638))

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -187,12 +187,10 @@ def perform_request(
             auth=auth,
             params=params,
             json=json,
-            timeout=timeout,
+            timeout=1,
         )
         response_json = response.json()
     except simplejson.JSONDecodeError:
-        if response.status_code == 504:
-            dds_cli.exceptions.ApiResponseError(message="The request to the API timed out.")
         raise dds_cli.exceptions.ApiResponseError(
             message=f"Response code: {response.status_code}. The request did not return a response message."
         )

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -192,7 +192,10 @@ def perform_request(
         response_json = response.json()
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(
-            message=f"Response code: {response.status_code}. The request did not return a response message. Details: {err}"
+            message=(
+                f"Response code: {response.status_code}. "
+                f"The request did not return a response message. Details: {err}"
+            )
         )
     except requests.exceptions.RequestException as err:
         if isinstance(err, requests.exceptions.ConnectionError):

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -190,9 +190,9 @@ def perform_request(
             timeout=1,
         )
         response_json = response.json()
-    except simplejson.JSONDecodeError:
+    except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(
-            message=f"Response code: {response.status_code}. The request did not return a response message."
+            message=f"Response code: {response.status_code}. The request did not return a response message. Details: {err}"
         )
     except requests.exceptions.RequestException as err:
         if isinstance(err, requests.exceptions.ConnectionError):

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -191,7 +191,7 @@ def perform_request(
         )
         response_json = response.json()
     except simplejson.JSONDecodeError as err:
-        raise dds_cli.exceptions.ApiResponseError(message=str(err))
+        raise dds_cli.exceptions.ApiResponseError(message=f"Response code: {response.status_code}. The request did not return a response message.")
     except requests.exceptions.RequestException as err:
         if isinstance(err, requests.exceptions.ConnectionError):
             error_message += ": The database seems to be down."

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -194,7 +194,7 @@ def perform_request(
         raise dds_cli.exceptions.ApiResponseError(
             message=(
                 f"Response code: {response.status_code}. "
-                f"The request did not return a response message. Details: {err}"
+                f"The request did not return a valid JSON response. Details: {err}"
             )
         )
     except requests.exceptions.RequestException as err:

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -190,7 +190,9 @@ def perform_request(
             timeout=timeout,
         )
         response_json = response.json()
-    except simplejson.JSONDecodeError as err:
+    except simplejson.JSONDecodeError:
+        if response.status_code == 504:
+            dds_cli.exceptions.ApiResponseError(message="The request to the API timed out.")
         raise dds_cli.exceptions.ApiResponseError(
             message=f"Response code: {response.status_code}. The request did not return a response message."
         )

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -187,7 +187,7 @@ def perform_request(
             auth=auth,
             params=params,
             json=json,
-            timeout=1,
+            timeout=timeout,
         )
         response_json = response.json()
     except simplejson.JSONDecodeError as err:

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -191,7 +191,9 @@ def perform_request(
         )
         response_json = response.json()
     except simplejson.JSONDecodeError as err:
-        raise dds_cli.exceptions.ApiResponseError(message=f"Response code: {response.status_code}. The request did not return a response message.")
+        raise dds_cli.exceptions.ApiResponseError(
+            message=f"Response code: {response.status_code}. The request did not return a response message."
+        )
     except requests.exceptions.RequestException as err:
         if isinstance(err, requests.exceptions.ConnectionError):
             error_message += ": The database seems to be down."


### PR DESCRIPTION
## Before submitting this PR

1. **Description:** When there is no json response from the API, the CLI prints out an error that is not understandable. This risks confusing both us and users. Could happen during a timeout for example. This PR updates the error message.  
2. **Jira task / GitHub issue:** DDS-1584
3. **How to test:** _Add information on how someone could manually test this functionality. As detailed as possible._
4. **Type of change:** [_Check the relevant boxes in the section below_](#what-type-of-changes-does-the-pr-contain)
5. **Add docstrings and comments to code**, _even if_ you personally think it's obvious.

## What _type of change(s)_ does the PR contain?

<!--
- "Breaking": The change will cause existing functionality to not work as expected.
- Workflow: E.g. a new github action or changes to this PR template. Anything that alters our or the codes workflow.
-->

- [ ] New feature
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [ ] Non-breaking
- [x] Bug fix
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [x] Non-breaking
- [ ] Security Alert fix
- [ ] Documentation
- [ ] Tests **(only)**
- [ ] Workflow

## Checklist

- [Sprintlog](../SPRINTLOG.md)
  - [x] Added
  - [ ] Not needed (E.g. PR contains _only_ tests)
- Rebase / Update / Merge _from_ base branch (the branch from which the current is forked)
  - [ ] Done
  - [x] Not needed
- Blocking PRs
  - [ ] Merged
  - [x] No blocking PRs
- PR to `master` branch
  - [ ] Yes: Read [the release instructions](../docs/procedures/new_release.md)
    - [ ] I have followed steps 1-7.
  - [x] No

## Actions / Scans

<!-- Go through all checkboxes. All actions must pass before merging is allowed.-->

- **Black**: Python code formatter. Does not execute. Only tests.
  Run `black .` locally to execute formatting.
  - [x] Passed
- **Pylint**: Python code linter. Does not execute. Only tests.
  Fix code producing warnings. Code must get 10/10.
  - [ ] Warnings fixed
  - [x] Passed
- **Prettier**: General code formatter. Our use case: MD and yaml mainly.
  Run `npx prettier --write .` locally to execute formatting.
  - [x] Passed
- **Yamllint**: Linting of yaml files.
  - [x] Passed
- **Tests**: Pytest to verify that functionality works as expected.
  - [ ] New tests added
  - [x] No new tests
  - [x] Passed
- **TestPyPi**: Build CLI and publish to TestPyPi in order to verify before release.
  - [x] Passed
- **CodeQL**: Scan for security vulnerabilities, bugs, errors
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Trivy**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Snyk**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
