### PR TITLE
Dds 1401 print project info when deleting archiving project

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -301,4 +301,4 @@ _Nothing merged in CLI during this sprint_
 # 2023-09-18 - 2023-09-29
 
 - GitHub Actions to generate the documentation fixed ([#1473])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1473)
-- Print project information when asking for confirmation for deletion or achiving ([#1401])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1401)
+- Print project information and ask user for confirmation when deleting or archiving projects ([#1401])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1401)

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -301,3 +301,4 @@ _Nothing merged in CLI during this sprint_
 # 2023-09-18 - 2023-09-29
 
 - GitHub Actions to generate the documentation fixed ([#1473])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1473)
+- Print project information when asking for confirmation of deletion ([#1401])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1401)

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -301,4 +301,4 @@ _Nothing merged in CLI during this sprint_
 # 2023-09-18 - 2023-09-29
 
 - GitHub Actions to generate the documentation fixed ([#1473])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1473)
-- Print project information when asking for confirmation of deletion ([#1401])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1401)
+- Print project information when asking for confirmation for deletion or achiving ([#1401])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1401)

--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -1196,28 +1196,22 @@ def archive_project(click_ctx, project: str, abort: bool = False):
 
     Use the `--abort` flag to indicate that something has gone wrong in the project.
     """
-    proceed_deletion = (
-        True
-        if click_ctx.get("NO_PROMPT", False)
-        else dds_cli.utils.get_deletion_confirmation(action="archive", project=project)
-    )
-    if proceed_deletion:
-        try:
-            with dds_cli.project_status.ProjectStatusManager(
-                project=project,
-                no_prompt=click_ctx.get("NO_PROMPT", False),
-                token_path=click_ctx.get("TOKEN_PATH"),
-            ) as updater:
-                updater.update_status(new_status="Archived", is_aborted=abort)
-        except (
-            dds_cli.exceptions.APIError,
-            dds_cli.exceptions.AuthenticationError,
-            dds_cli.exceptions.DDSCLIException,
-            dds_cli.exceptions.ApiResponseError,
-            dds_cli.exceptions.ApiRequestError,
-        ) as err:
-            LOG.error(err)
-            sys.exit(1)
+    try:
+        with dds_cli.project_status.ProjectStatusManager(
+            project=project,
+            no_prompt=click_ctx.get("NO_PROMPT", False),
+            token_path=click_ctx.get("TOKEN_PATH"),
+        ) as updater:
+            updater.update_status(new_status="Archived", is_aborted=abort)
+    except (
+        dds_cli.exceptions.APIError,
+        dds_cli.exceptions.AuthenticationError,
+        dds_cli.exceptions.DDSCLIException,
+        dds_cli.exceptions.ApiResponseError,
+        dds_cli.exceptions.ApiRequestError,
+    ) as err:
+        LOG.error(err)
+        sys.exit(1)
 
 
 # -- dds project status delete -- #
@@ -1231,28 +1225,22 @@ def delete_project(click_ctx, project: str):
     Certain meta data is kept (nothing sensitive) and it will still be listed in your projects. All
     data within the project is deleted. You cannot revert this change.
     """
-    proceed_deletion = (
-        True
-        if click_ctx.get("NO_PROMPT", False)
-        else dds_cli.utils.get_deletion_confirmation(action="delete", project=project)
-    )
-    if proceed_deletion:
-        try:
-            with dds_cli.project_status.ProjectStatusManager(
-                project=project,
-                no_prompt=click_ctx.get("NO_PROMPT", False),
-                token_path=click_ctx.get("TOKEN_PATH"),
-            ) as updater:
-                updater.update_status(new_status="Deleted")
-        except (
-            dds_cli.exceptions.APIError,
-            dds_cli.exceptions.AuthenticationError,
-            dds_cli.exceptions.DDSCLIException,
-            dds_cli.exceptions.ApiResponseError,
-            dds_cli.exceptions.ApiRequestError,
-        ) as err:
-            LOG.error(err)
-            sys.exit(1)
+    try:
+        with dds_cli.project_status.ProjectStatusManager(
+            project=project,
+            no_prompt=click_ctx.get("NO_PROMPT", False),
+            token_path=click_ctx.get("TOKEN_PATH"),
+        ) as updater:
+            updater.update_status(new_status="Deleted")
+    except (
+        dds_cli.exceptions.APIError,
+        dds_cli.exceptions.AuthenticationError,
+        dds_cli.exceptions.DDSCLIException,
+        dds_cli.exceptions.ApiResponseError,
+        dds_cli.exceptions.ApiRequestError,
+    ) as err:
+        LOG.error(err)
+        sys.exit(1)
 
 
 # -- dds project status busy -- #

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -148,6 +148,11 @@ class DDSBaseClass:
         )
 
         project_info = response.get("project_info")
+
+        # If not project info was retrieved from the request, throw an exception
+        if not project_info:
+            raise dds_cli.exceptions.ApiResponseError(message="No project information to display.")
+
         return project_info
 
     def generate_project_table(self, project_info):

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -133,7 +133,7 @@ class DDSBaseClass:
 
         return True
 
-    # Private methods ############################### Private methods #
+    # Public methods ############################### Public methods #
 
     def get_project_info(self):
         """Collect project information from API."""

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -148,9 +148,6 @@ class DDSBaseClass:
         )
 
         project_info = response.get("project_info")
-        if not project_info:
-            raise dds_cli.exceptions.ApiResponseError(message="No project information to display.")
-
         return project_info
 
     def generate_project_table(self, project_info):

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -134,6 +134,41 @@ class DDSBaseClass:
         return True
 
     # Private methods ############################### Private methods #
+
+    def get_project_info(self):
+        """Collect project information from API."""
+
+        # Get info about a project from API
+        response, _ = dds_cli.utils.perform_request(
+            DDSEndpoint.PROJ_INFO,
+            method="get",
+            headers=self.token,
+            params={"project": self.project},
+            error_message="Failed to get project information",
+        )
+
+        project_info = response.get("project_info")
+        if not project_info:
+            raise dds_cli.exceptions.ApiResponseError(message="No project information to display.")
+
+        return project_info
+
+    def generate_project_table(self, project_info):
+        """Generate a table from some project info provided"""
+
+        # Print project info table
+        table = dds_cli.utils.create_table(
+            title="Project information.",
+            columns=["Project ID", "Created by", "Status", "Last updated", "Size"],
+            rows=[
+                project_info,
+            ],
+            caption=f"Information about project {project_info['Project ID']}",
+        )
+
+        return table
+
+    # Private methods ############################### Private methods #
     def __get_safespring_keys(self):
         """Get safespring keys."""
         return s3.S3Connector(project_id=self.project, token=self.token)

--- a/dds_cli/project_info.py
+++ b/dds_cli/project_info.py
@@ -44,37 +44,13 @@ class ProjectInfoManager(base.DDSBaseClass):
         self.project = project
 
     # Public methods ###################### Public methods #
-    def get_project_info(self):
-        """Collect project information from API."""
-        # Get info about a project from API
-        response, _ = dds_cli.utils.perform_request(
-            DDSEndpoint.PROJ_INFO,
-            method="get",
-            headers=self.token,
-            params={"project": self.project},
-            error_message="Failed to get project information",
-        )
-
-        project_info = response.get("project_info")
-        if not project_info:
-            raise dds_cli.exceptions.ApiResponseError(message="No project information to display.")
-
-        return project_info
 
     def show_project_info(self):
         """Display info about a project."""
-        # Get project info from API
-        project_info = self.get_project_info()
 
-        # Print project info table
-        table = dds_cli.utils.create_table(
-            title="Project information.",
-            columns=["Project ID", "Created by", "Status", "Last updated", "Size"],
-            rows=[
-                project_info,
-            ],
-            caption=f"Information about project {project_info['Project ID']}",
-        )
+        # Get project info from api
+        project_info = self.get_project_info()
+        table = self.generate_project_table(project_info=project_info)
         dds_cli.utils.console.print(table)
 
         # Print Title and Description below the table

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -124,7 +124,6 @@ class ProjectStatusManager(base.DDSBaseClass):
 
         # If the status is going to be archived or deleted. Ask for confirmation
         if new_status in ["Archived", "Deleted"]:
-
             # get project info
             project_info = self.get_project_info()
 

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -52,6 +52,7 @@ class ProjectStatusManager(base.DDSBaseClass):
     def get_project_info(self):
         """Collect project information from API."""
         # Get info about a project from API
+
         response, _ = dds_cli.utils.perform_request(
             DDSEndpoint.PROJ_INFO,
             method="get",
@@ -61,9 +62,6 @@ class ProjectStatusManager(base.DDSBaseClass):
         )
 
         project_info = response.get("project_info")
-        if not project_info:
-            raise dds_cli.exceptions.ApiResponseError(message="No project information to display.")
-
         return project_info
 
     def get_status(self, show_history):

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -114,7 +114,7 @@ class ProjectStatusManager(base.DDSBaseClass):
                 project_info = self.get_project_info()
             except exceptions.ApiResponseError:
                 dds_cli.utils.console.print(
-                    f"No project information could be displayed at this moment!"
+                    "No project information could be displayed at this moment!"
                 )
             else:
                 table = self.generate_project_table(project_info=project_info)

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -33,12 +33,14 @@ class ProjectStatusManager(base.DDSBaseClass):
     def __init__(
         self,
         project: str,
+        authenticate: bool = True,
         no_prompt: bool = False,
         token_path: str = None,
     ):
         """Handle actions regarding project status in the cli."""
         # Initiate DDSBaseClass to authenticate user
         super().__init__(
+            authenticate=authenticate,
             no_prompt=no_prompt,
             method_check=False,
             token_path=token_path,
@@ -128,12 +130,12 @@ class ProjectStatusManager(base.DDSBaseClass):
             project_info = self.get_project_info()
 
             # Create confirmation prompt with project info
-            question = (
+            print_info = (
                 f"Are you sure you want to modify the status of {self.project}? All its contents "
             )
             if new_status == "Deleted":
-                question = question + "and metainfo "
-            question += (
+                print_info += "and metainfo "
+            print_info += (
                 "will be deleted!\n"
                 f"The project '[b]{self.project}[/b]' is about to be [b][blue]{new_status}[/blue][/b].\n"
                 f"Title: \t{project_info['Title']}\n"
@@ -141,7 +143,9 @@ class ProjectStatusManager(base.DDSBaseClass):
                 f"PI: \t{project_info['PI']}\n"
             )
 
-            if not rich.prompt.Confirm.ask(question):
+            dds_cli.utils.console.print(print_info)
+
+            if not rich.prompt.Confirm.ask("-"):
                 LOG.info("Probably for the best. Exiting.")
                 sys.exit(0)
 

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -114,7 +114,7 @@ class ProjectStatusManager(base.DDSBaseClass):
                 project_info = self.get_project_info()
             except exceptions.ApiResponseError:
                 dds_cli.utils.console.print(
-                    f"No project information could be displayed at this moment!. You can continue with the operation if you want"
+                    f"No project information could be displayed at this moment!"
                 )
             else:
                 table = self.generate_project_table(project_info=project_info)

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -49,21 +49,6 @@ class ProjectStatusManager(base.DDSBaseClass):
 
     # Public methods ###################### Public methods #
 
-    def get_project_info(self):
-        """Collect project information from API."""
-        # Get info about a project from API
-
-        response, _ = dds_cli.utils.perform_request(
-            DDSEndpoint.PROJ_INFO,
-            method="get",
-            headers=self.token,
-            params={"project": self.project},
-            error_message="Failed to get project information",
-        )
-
-        project_info = response.get("project_info")
-        return project_info
-
     def get_status(self, show_history):
         """Get current status and status history of the project."""
         resp_json, _ = dds_cli.utils.perform_request(
@@ -126,19 +111,17 @@ class ProjectStatusManager(base.DDSBaseClass):
         if new_status in ["Archived", "Deleted"]:
             # get project info
             project_info = self.get_project_info()
+            table = self.generate_project_table(project_info=project_info)
+            dds_cli.utils.console.print(table)
 
-            # Create confirmation prompt with project info
+            # Create confirmation prompt
             print_info = (
                 f"Are you sure you want to modify the status of {self.project}? All its contents "
             )
             if new_status == "Deleted":
                 print_info += "and metainfo "
             print_info += (
-                "will be deleted!\n"
-                f"The project '[b]{self.project}[/b]' is about to be [b][blue]{new_status}[/blue][/b].\n"
-                f"Title: \t{project_info['Title']}\n"
-                f"Description: \t{project_info['Description']}\n"
-                f"PI: \t{project_info['PI']}\n"
+                "will be deleted!\n" f"The project {self.project} is about to be {new_status}.\n"
             )
 
             dds_cli.utils.console.print(print_info)

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -63,7 +63,7 @@ class ProjectStatusManager(base.DDSBaseClass):
             raise dds_cli.exceptions.ApiResponseError(message="No project information to display.")
 
         return project_info
-    
+
     def get_status(self, show_history):
         """Get current status and status history of the project."""
         resp_json, _ = dds_cli.utils.perform_request(
@@ -121,16 +121,18 @@ class ProjectStatusManager(base.DDSBaseClass):
             extra_params["deadline"] = deadline
         if is_aborted:
             extra_params["is_aborted"] = is_aborted
-        
-        # If the status is going to be archived or deleted. Ask for confirmation
-        if new_status in ["Archived","Deleted"]:
 
-            #get project info
+        # If the status is going to be archived or deleted. Ask for confirmation
+        if new_status in ["Archived", "Deleted"]:
+
+            # get project info
             project_info = self.get_project_info()
 
             # Create confirmation prompt with project info
-            question = f"Are you sure you want to modify the status of {self.project}? All its contents "
-            if new_status == 'Deleted':
+            question = (
+                f"Are you sure you want to modify the status of {self.project}? All its contents "
+            )
+            if new_status == "Deleted":
                 question = question + "and metainfo "
             question += (
                 "will be deleted!\n"

--- a/dds_cli/project_status.py
+++ b/dds_cli/project_status.py
@@ -110,9 +110,15 @@ class ProjectStatusManager(base.DDSBaseClass):
         # If the status is going to be archived or deleted. Ask for confirmation
         if new_status in ["Archived", "Deleted"]:
             # get project info
-            project_info = self.get_project_info()
-            table = self.generate_project_table(project_info=project_info)
-            dds_cli.utils.console.print(table)
+            try:
+                project_info = self.get_project_info()
+            except exceptions.ApiResponseError:
+                dds_cli.utils.console.print(
+                    f"No project information could be displayed at this moment!. You can continue with the operation if you want"
+                )
+            else:
+                table = self.generate_project_table(project_info=project_info)
+                dds_cli.utils.console.print(table)
 
             # Create confirmation prompt
             print_info = (
@@ -121,7 +127,8 @@ class ProjectStatusManager(base.DDSBaseClass):
             if new_status == "Deleted":
                 print_info += "and metainfo "
             print_info += (
-                "will be deleted!\n" f"The project {self.project} is about to be {new_status}.\n"
+                "will be deleted!\n"
+                f"The project '{self.project}' is about to be [b][blue]{new_status}[/blue][/b].\n"
             )
 
             dds_cli.utils.console.print(print_info)

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -267,7 +267,7 @@ def test_no_project_info(capsys: CaptureFixture, monkeypatch):
             json_project_info={"project_info": {}},
         )
         assert (
-            "No project information could be displayed at this moment!. You can continue with the operation if you want"
+            "No project information could be displayed at this moment!"
             in capsys.readouterr().out
         )
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -207,25 +207,13 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
 def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
     """Test that tries to delete a project, the user accepts the operation"""
 
+    confirmed = True
     # Create mocker
     with Mocker() as mock:
-        # Create mocked request - real request not executed
-        mock.get(
-            DDSEndpoint.PROJ_INFO,
-            status_code=200,
-            json={"project_info": returned_response_get_info},
-        )
-        mock.post(
-            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_deleted_ok
-        )
-        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 
-        with project_status.ProjectStatusManager(
-            project=project_name, no_prompt=True, authenticate=False
-        ) as status_mngr:
-            status_mngr.token = {}  # required, otherwise none
-            status_mngr.update_status(new_status="Deleted")
-
+        # set confirmation object to true
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
+        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed)
         assert returned_response_deleted_ok["message"] in capsys.readouterr().out
 
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -110,6 +110,7 @@ def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: 
         assert (
             f"Are you sure you want to modify the status of {project_name}?" in captured_output[0]
         )
+        assert "The project 'Test' is about to be Archived." in captured_output[1]
         assert f"Title:  {returned_response_get_info['Title']}" in captured_output[2]
         assert f"Description:    {returned_response_get_info['Description']}" in captured_output[3]
         assert f"PI:     {returned_response_get_info['PI']}" in captured_output[4]

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -49,13 +49,13 @@ def perform_archive_delete_operation(new_status, confirmed, mock):
                 project=project_name, no_prompt=True, authenticate=False
             ) as status_mngr:
                 status_mngr.token = {}  # required, otherwise none
-                status_mngr.update_status(new_status="Deleted")
+                status_mngr.update_status(new_status=new_status)
     else:
         with project_status.ProjectStatusManager(
             project=project_name, no_prompt=True, authenticate=False
         ) as status_mngr:
             status_mngr.token = {}  # required, otherwise none
-            status_mngr.update_status(new_status="Deleted")
+            status_mngr.update_status(new_status=new_status)
 
 
 # tests

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -108,8 +108,7 @@ def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: 
         captured_output = captured_output.split("\n")
 
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents will be deleted!"
-            in captured_output[0]
+            f"Are you sure you want to modify the status of {project_name}?" in captured_output[0]
         )
         assert f"Title:  {returned_response_get_info['Title']}" in captured_output[2]
         assert f"Description:    {returned_response_get_info['Description']}" in captured_output[3]

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -133,7 +133,6 @@ def test_release_project(capsys: CaptureFixture):
 
 
 def check_output_project_info(new_status, captured_output, caplog_tuples=None):
-
     assert f"The project '{project_name}' is about to be {new_status}." in captured_output.out
     assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
     assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
@@ -210,7 +209,9 @@ def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
         # set confirmation object to true
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
         perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
-        assert returned_response_deleted_ok["message"] in capsys.readouterr().out
+        captured_output = capsys.readouterr()
+
+        assert returned_response_deleted_ok["message"] in captured_output.out
         # check the rest of the project info is displayed correctly
         check_output_project_info(
             new_status="Deleted", captured_output=captured_output, caplog_tuples=None
@@ -226,7 +227,9 @@ def test_archive_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCap
         # set confirmation object to true
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
         perform_archive_delete_operation(new_status="Archived", confirmed=confirmed, mock=mock)
-        assert returned_response_archived_ok["message"] in capsys.readouterr().out
+        captured_output = capsys.readouterr()
+
+        assert returned_response_archived_ok["message"] in captured_output.out
         check_output_project_info(
             new_status="Archived", captured_output=captured_output, caplog_tuples=None
         )

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -104,7 +104,7 @@ def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: 
                 status_mngr.token = {}  # required, otherwise none
                 status_mngr.update_status(new_status="Archived")
 
-        captured_output = capsys.readouterr().out
+        captured_output = capsys.readouterr()
 
         assert (
             f"Are you sure you want to modify the status of {project_name}?" in captured_output.out

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -128,8 +128,9 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
 
         captured_output = capsys.readouterr()
 
+        # for some reason the log includees a line break here
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents and metainfo will be"
+            f"Are you sure you want to modify the status of {project_name}? All its contents and \nmetainfo will be"
             in captured_output.out
         )
         assert "The project 'Test' is about to be Deleted." in captured_output.out

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -267,8 +267,7 @@ def test_no_project_info(capsys: CaptureFixture, monkeypatch):
             json_project_info={"project_info": {}},
         )
         assert (
-            "No project information could be displayed at this moment!"
-            in capsys.readouterr().out
+            "No project information could be displayed at this moment!" in capsys.readouterr().out
         )
 
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -5,7 +5,7 @@ from dds_cli import project_status
 from _pytest.logging import LogCaptureFixture
 from _pytest.capture import CaptureFixture
 import logging
-from dds_cli.exceptions import ApiResponseError,DDSCLIException
+from dds_cli.exceptions import ApiResponseError, DDSCLIException
 
 import typing
 
@@ -14,14 +14,25 @@ import typing
 #########
 
 project_name = "Test"
-returned_response_get_info: typing.Dict = {'Title': 'Test', 'Description': 'a description', 'PI':'pi@a.se'}
-returned_response_available_ok: typing.Dict = {'message':f'{project_name} updated to status Available. An e-mail notification has been sent.'}
-returned_response_archived_ok: typing.Dict = {'message':f'{project_name} updated to status Archived. An e-mail notification has been sent.'}
-returned_response_deleted_ok: typing.Dict = {'message':f'{project_name} updated to status Deleted. An e-mail notification has been sent.'}
+returned_response_get_info: typing.Dict = {
+    "Title": "Test",
+    "Description": "a description",
+    "PI": "pi@a.se",
+}
+returned_response_available_ok: typing.Dict = {
+    "message": f"{project_name} updated to status Available. An e-mail notification has been sent."
+}
+returned_response_archived_ok: typing.Dict = {
+    "message": f"{project_name} updated to status Archived. An e-mail notification has been sent."
+}
+returned_response_deleted_ok: typing.Dict = {
+    "message": f"{project_name} updated to status Deleted. An e-mail notification has been sent."
+}
 
 #########
 
 # tests
+
 
 def test_init_project_status_manager():
     """Create manager."""
@@ -32,9 +43,9 @@ def test_init_project_status_manager():
 
 
 def test_fail_update_project(capsys: CaptureFixture):
-    """ Test that fails when trying to update the project status"""
+    """Test that fails when trying to update the project status"""
 
-    # Create mocker    
+    # Create mocker
     with Mocker() as mock:
         # Create mocked request - real request not executed
         mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json=returned_response_get_info)
@@ -51,13 +62,15 @@ def test_fail_update_project(capsys: CaptureFixture):
 
 
 def test_release_project(capsys: CaptureFixture):
-    """ Test that tries to release a project and seeting up as available"""
+    """Test that tries to release a project and seeting up as available"""
 
-    # Create mocker    
+    # Create mocker
     with Mocker() as mock:
         # Create mocked request - real request not executed
         mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json=returned_response_get_info)
-        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_available_ok)
+        mock.post(
+            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_available_ok
+        )
 
         with project_status.ProjectStatusManager(
             project=project_name, no_prompt=True, authenticate=False
@@ -65,19 +78,23 @@ def test_release_project(capsys: CaptureFixture):
             status_mngr.token = {}  # required, otherwise none
             status_mngr.update_status(new_status="Available")
 
-        assert returned_response_available_ok['message'] in capsys.readouterr().out
+        assert returned_response_available_ok["message"] in capsys.readouterr().out
 
-    
+
 def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
     """Test that tries to archive/delete a project, but the user selects no to perfrom the operation"""
 
     caplog.set_level(logging.INFO)
-    # Create mocker    
+    # Create mocker
     with Mocker() as mock:
         # Create mocked request - real request not executed
-        mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json={"project_info": returned_response_get_info})
+        mock.get(
+            DDSEndpoint.PROJ_INFO,
+            status_code=200,
+            json={"project_info": returned_response_get_info},
+        )
         mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json={})
-        monkeypatch.setattr('rich.prompt.Confirm.ask', lambda question: False)
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: False)
 
         # capture system exit on not accepting operation
         with pytest.raises(SystemExit):
@@ -90,7 +107,10 @@ def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: 
         captured_output = capsys.readouterr().out
         captured_output = captured_output.split("\n")
 
-        assert f"Are you sure you want to modify the status of {project_name}? All its contents will be deleted!" in captured_output[0]
+        assert (
+            f"Are you sure you want to modify the status of {project_name}? All its contents will be deleted!"
+            in captured_output[0]
+        )
         assert f"Title:  {returned_response_get_info['Title']}" in captured_output[2]
         assert f"Description:    {returned_response_get_info['Description']}" in captured_output[3]
         assert f"PI:     {returned_response_get_info['PI']}" in captured_output[4]
@@ -101,15 +121,22 @@ def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: 
             "Probably for the best. Exiting.",
         ) in caplog.record_tuples
 
+
 def test_archive_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
     """Test that tries to archive/delete a project, the user accepts the operation"""
 
-    # Create mocker    
+    # Create mocker
     with Mocker() as mock:
         # Create mocked request - real request not executed
-        mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json={"project_info": returned_response_get_info})
-        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_archived_ok)
-        monkeypatch.setattr('rich.prompt.Confirm.ask', lambda question: True)
+        mock.get(
+            DDSEndpoint.PROJ_INFO,
+            status_code=200,
+            json={"project_info": returned_response_get_info},
+        )
+        mock.post(
+            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_archived_ok
+        )
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 
         with project_status.ProjectStatusManager(
             project=project_name, no_prompt=True, authenticate=False
@@ -117,4 +144,4 @@ def test_archive_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog:
             status_mngr.token = {}  # required, otherwise none
             status_mngr.update_status(new_status="Archived")
 
-        assert returned_response_archived_ok['message'] in capsys.readouterr().out
+        assert returned_response_archived_ok["message"] in capsys.readouterr().out

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -61,6 +61,20 @@ def perform_archive_delete_operation(new_status, confirmed, mock):
             status_mngr.update_status(new_status=new_status)
 
 
+def check_output_project_info(new_status, captured_output, caplog_tuples=None):
+    assert f"The project '{project_name}' is about to be {new_status}." in captured_output.out
+    assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
+    assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
+    assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
+
+    if caplog_tuples:
+        assert (
+            "dds_cli.project_status",
+            logging.INFO,
+            "Probably for the best. Exiting.",
+        ) in caplog_tuples
+
+
 # tests
 
 
@@ -130,20 +144,6 @@ def test_release_project(capsys: CaptureFixture):
             status_mngr.update_status(new_status="Available")
 
         assert returned_response_available_ok["message"] in capsys.readouterr().out
-
-
-def check_output_project_info(new_status, captured_output, caplog_tuples=None):
-    assert f"The project '{project_name}' is about to be {new_status}." in captured_output.out
-    assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
-    assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
-    assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
-
-    if caplog_tuples:
-        assert (
-            "dds_cli.project_status",
-            logging.INFO,
-            "Probably for the best. Exiting.",
-        ) in caplog_tuples
 
 
 def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -215,7 +215,7 @@ def test_archive_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog:
         assert returned_response_deleted_ok["message"] in capsys.readouterr().out
 
 
-def test_update_extra_params(capsys: CaptureFixture):
+def test_update_extra_params(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
     """Test that update the project status providing extra params"""
 
     # Create mocker

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -70,16 +70,14 @@ def test_fail_display_project_info(capsys: CaptureFixture):
         mock.get(DDSEndpoint.PROJ_INFO, status_code=403, json={})
         mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json={})
 
-        with pytest.raises(DDSCLIException) as err_1:
-            with pytest.raises(ApiResponseError) as err_2:
-                with project_status.ProjectStatusManager(
-                    project=project_name, no_prompt=True, authenticate=False
-                ) as status_mngr:
-                    status_mngr.token = {}  # required, otherwise none
-                    status_mngr.update_status(new_status="Archived")
+        with pytest.raises(DDSCLIException) as err:
+            with project_status.ProjectStatusManager(
+                project=project_name, no_prompt=True, authenticate=False
+            ) as status_mngr:
+                status_mngr.token = {}  # required, otherwise none
+                status_mngr.update_status(new_status="Archived")
 
-            assert "No project information to display" in str(err_2.value)
-        assert "Failed to get project information" in str(err_1.value)
+        assert "Failed to get project information:" in str(err.value)
 
 
 def test_release_project(capsys: CaptureFixture):

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -105,15 +105,14 @@ def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: 
                 status_mngr.update_status(new_status="Archived")
 
         captured_output = capsys.readouterr().out
-        captured_output = captured_output.split("\n")
 
         assert (
-            f"Are you sure you want to modify the status of {project_name}?" in captured_output[0]
+            f"Are you sure you want to modify the status of {project_name}?" in captured_output.out
         )
-        assert "The project 'Test' is about to be Archived." in captured_output[1]
-        assert f"Title:  {returned_response_get_info['Title']}" in captured_output[2]
-        assert f"Description:    {returned_response_get_info['Description']}" in captured_output[3]
-        assert f"PI:     {returned_response_get_info['PI']}" in captured_output[4]
+        assert "The project 'Test' is about to be Archived." in captured_output.out
+        assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
+        assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
+        assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
 
         assert (
             "dds_cli.project_status",

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -70,7 +70,6 @@ def perform_archive_delete_operation(new_status, confirmed, mock, json_project_i
 
 
 def check_output_project_info(new_status, captured_output, caplog_tuples=None):
-
     # Becuase of the bold and coloring formating, it is better to test for this keyworkd. Insetad of trying to find
     # the whole string The project 'project_1' is about to be Deleted.
     assert f"{project_name}" in captured_output.out
@@ -258,7 +257,6 @@ def test_no_project_info(capsys: CaptureFixture, monkeypatch):
     confirmed = True
     # Create mocker
     with Mocker() as mock:
-
         # set confirmation object to True
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -25,6 +25,9 @@ returned_response_archived_ok: typing.Dict = {
 returned_response_deleted_ok: typing.Dict = {
     "message": f"{project_name} updated to status Deleted. An e-mail notification has been sent."
 }
+returned_response_available_ok: typing.Dict = {
+    "message": f"{project_name} updated to status Available. An e-mail notification has been sent."
+}
 
 #########
 
@@ -110,10 +113,6 @@ def test_fail_display_project_info(capsys: CaptureFixture):
 def test_release_project(capsys: CaptureFixture):
     """Test that tries to release a project and seeting up as available"""
 
-    returned_response_available_ok: typing.Dict = {
-        "message": f"{project_name} updated to status Available. An e-mail notification has been sent."
-    }
-
     # Create mocker
     with Mocker() as mock:
         # Create mocked request - real request not executed
@@ -131,6 +130,20 @@ def test_release_project(capsys: CaptureFixture):
             status_mngr.update_status(new_status="Available")
 
         assert returned_response_available_ok["message"] in capsys.readouterr().out
+
+
+def check_output_project_info(captured_output, caplog_tuples=None):
+    assert "The project 'Test' is about to be Deleted." in captured_output.out
+    assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
+    assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
+    assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
+
+    if caplog_tuples:
+        assert (
+            "dds_cli.project_status",
+            logging.INFO,
+            "Probably for the best. Exiting.",
+        ) in caplog_tuples
 
 
 def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
@@ -151,16 +164,11 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
             f"Are you sure you want to modify the status of {project_name}? All its contents and \nmetainfo will be deleted!"
             in captured_output.out
         )
-        assert "The project 'Test' is about to be Deleted." in captured_output.out
-        assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
-        assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
-        assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
 
-        assert (
-            "dds_cli.project_status",
-            logging.INFO,
-            "Probably for the best. Exiting.",
-        ) in caplog.record_tuples
+        # check the rest of the project info is displayed correctly
+        check_output_project_info(
+            captured_output=captured_output, caplog_tuples=caplog.record_tuples
+        )
 
 
 def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
@@ -181,16 +189,11 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
             f"Are you sure you want to modify the status of {project_name}? All its contents will be \ndeleted!"
             in captured_output.out
         )
-        assert "The project 'Test' is about to be Archived." in captured_output.out
-        assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
-        assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
-        assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
 
-        assert (
-            "dds_cli.project_status",
-            logging.INFO,
-            "Probably for the best. Exiting.",
-        ) in caplog.record_tuples
+        # check the rest of the project info is displayed correctly
+        check_output_project_info(
+            captured_output=captured_output, caplog_tuples=caplog.record_tuples
+        )
 
 
 def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -29,36 +29,7 @@ returned_response_deleted_ok: typing.Dict = {
     "message": f"{project_name} updated to status Deleted. An e-mail notification has been sent."
 }
 
-############ Helper functions
-
-
-def perfom_archive_delete(mock, new_status, confirmed=False):
-
-    # Create mocked request - real request not executed
-    mock.get(
-        DDSEndpoint.PROJ_INFO,
-        status_code=200,
-        json={"project_info": returned_response_get_info},
-    )
-    mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json={})
-
-    if not confirmed:
-        # capture system exit on not accepting operation
-        with pytest.raises(SystemExit):
-            with project_status.ProjectStatusManager(
-                project=project_name, no_prompt=True, authenticate=False
-            ) as status_mngr:
-                status_mngr.token = {}  # required, otherwise none
-                status_mngr.update_status(new_status=new_status)
-    else:
-        with project_status.ProjectStatusManager(
-            project=project_name, no_prompt=True, authenticate=False
-        ) as status_mngr:
-            status_mngr.token = {}  # required, otherwise none
-            status_mngr.update_status(new_status=new_status)
-
-
-############
+#########
 
 # tests
 
@@ -133,14 +104,25 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
     """Test that tries to delete a project, but the user selects no to perfrom the operation"""
 
     caplog.set_level(logging.INFO)
-    confirmed = False
-
     # Create mocker
     with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(
+            DDSEndpoint.PROJ_INFO,
+            status_code=200,
+            json={"project_info": returned_response_get_info},
+        )
+        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json={})
         # set confirmation object to false
-        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: False)
 
-        perfom_archive_delete(mock=mock, new_status="Deleted", confirmed=confirmed)
+        # capture system exit on not accepting operation
+        with pytest.raises(SystemExit):
+            with project_status.ProjectStatusManager(
+                project=project_name, no_prompt=True, authenticate=False
+            ) as status_mngr:
+                status_mngr.token = {}  # required, otherwise none
+                status_mngr.update_status(new_status="Deleted")
 
         captured_output = capsys.readouterr()
 
@@ -166,14 +148,25 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
     """Test that tries to archive a project, but the user selects no to perfrom the operation"""
 
     caplog.set_level(logging.INFO)
-    confirmed = False
-
     # Create mocker
     with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(
+            DDSEndpoint.PROJ_INFO,
+            status_code=200,
+            json={"project_info": returned_response_get_info},
+        )
+        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json={})
         # set confirmation object to false
-        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: False)
 
-        perfom_archive_delete(mock=mock, new_status="Deleted", confirmed=confirmed)
+        # capture system exit on not accepting operation
+        with pytest.raises(SystemExit):
+            with project_status.ProjectStatusManager(
+                project=project_name, no_prompt=True, authenticate=False
+            ) as status_mngr:
+                status_mngr.token = {}  # required, otherwise none
+                status_mngr.update_status(new_status="Archived")
 
         captured_output = capsys.readouterr()
 
@@ -198,15 +191,24 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
 def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
     """Test that tries to delete a project, the user accepts the operation"""
 
-    confirmed = True
-
     # Create mocker
     with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(
+            DDSEndpoint.PROJ_INFO,
+            status_code=200,
+            json={"project_info": returned_response_get_info},
+        )
+        mock.post(
+            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_deleted_ok
+        )
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 
-        # set confirmation object to true
-        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-
-        perfom_archive_delete(mock=mock, new_status="Deleted", confirmed=confirmed)
+        with project_status.ProjectStatusManager(
+            project=project_name, no_prompt=True, authenticate=False
+        ) as status_mngr:
+            status_mngr.token = {}  # required, otherwise none
+            status_mngr.update_status(new_status="Deleted")
 
         assert returned_response_deleted_ok["message"] in capsys.readouterr().out
 
@@ -214,15 +216,24 @@ def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
 def test_archive_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
     """Test that tries to archive a project, the user accepts the operation"""
 
-    confirmed = True
-
     # Create mocker
     with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(
+            DDSEndpoint.PROJ_INFO,
+            status_code=200,
+            json={"project_info": returned_response_get_info},
+        )
+        mock.post(
+            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_archived_ok
+        )
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 
-        # set confirmation object to true
-        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-
-        perfom_archive_delete(mock=mock, new_status="Deleted", confirmed=confirmed)
+        with project_status.ProjectStatusManager(
+            project=project_name, no_prompt=True, authenticate=False
+        ) as status_mngr:
+            status_mngr.token = {}  # required, otherwise none
+            status_mngr.update_status(new_status="Archived")
 
         assert returned_response_archived_ok["message"] in capsys.readouterr().out
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -132,8 +132,9 @@ def test_release_project(capsys: CaptureFixture):
         assert returned_response_available_ok["message"] in capsys.readouterr().out
 
 
-def check_output_project_info(captured_output, caplog_tuples=None):
-    assert "The project 'Test' is about to be Deleted." in captured_output.out
+def check_output_project_info(new_status, captured_output, caplog_tuples=None):
+
+    assert f"The project '{project_name}' is about to be {new_status}." in captured_output.out
     assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
     assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
     assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
@@ -167,7 +168,9 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
 
         # check the rest of the project info is displayed correctly
         check_output_project_info(
-            captured_output=captured_output, caplog_tuples=caplog.record_tuples
+            new_status="Deleted",
+            captured_output=captured_output,
+            caplog_tuples=caplog.record_tuples,
         )
 
 
@@ -192,7 +195,9 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
 
         # check the rest of the project info is displayed correctly
         check_output_project_info(
-            captured_output=captured_output, caplog_tuples=caplog.record_tuples
+            new_status="Archived",
+            captured_output=captured_output,
+            caplog_tuples=caplog.record_tuples,
         )
 
 
@@ -206,6 +211,10 @@ def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
         perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
         assert returned_response_deleted_ok["message"] in capsys.readouterr().out
+        # check the rest of the project info is displayed correctly
+        check_output_project_info(
+            new_status="Deleted", captured_output=captured_output, caplog_tuples=None
+        )
 
 
 def test_archive_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
@@ -218,6 +227,9 @@ def test_archive_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCap
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
         perform_archive_delete_operation(new_status="Archived", confirmed=confirmed, mock=mock)
         assert returned_response_archived_ok["message"] in capsys.readouterr().out
+        check_output_project_info(
+            new_status="Archived", captured_output=captured_output, caplog_tuples=None
+        )
 
 
 def test_update_extra_params(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -1,0 +1,120 @@
+import pytest
+from requests_mock.mocker import Mocker
+from dds_cli import DDSEndpoint
+from dds_cli import project_status
+from _pytest.logging import LogCaptureFixture
+from _pytest.capture import CaptureFixture
+import logging
+from dds_cli.exceptions import ApiResponseError,DDSCLIException
+
+import typing
+
+# init
+
+#########
+
+project_name = "Test"
+returned_response_get_info: typing.Dict = {'Title': 'Test', 'Description': 'a description', 'PI':'pi@a.se'}
+returned_response_available_ok: typing.Dict = {'message':f'{project_name} updated to status Available. An e-mail notification has been sent.'}
+returned_response_archived_ok: typing.Dict = {'message':f'{project_name} updated to status Archived. An e-mail notification has been sent.'}
+returned_response_deleted_ok: typing.Dict = {'message':f'{project_name} updated to status Deleted. An e-mail notification has been sent.'}
+
+#########
+
+# tests
+
+def test_init_project_status_manager():
+    """Create manager."""
+    status_mngr: project_status.ProjectStatusManager = project_status.ProjectStatusManager(
+        project=project_name, no_prompt=True, authenticate=False
+    )
+    assert isinstance(status_mngr, project_status.ProjectStatusManager)
+
+
+def test_fail_update_project(capsys: CaptureFixture):
+    """ Test that fails when trying to update the project status"""
+
+    # Create mocker    
+    with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json=returned_response_get_info)
+        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=403, json={})
+
+        with pytest.raises(DDSCLIException) as err:
+            with project_status.ProjectStatusManager(
+                project=project_name, no_prompt=True, authenticate=False
+            ) as status_mngr:
+                status_mngr.token = {}  # required, otherwise none
+                status_mngr.update_status(new_status="Available")
+
+        assert "Failed to update project status" in str(err.value)
+
+
+def test_release_project(capsys: CaptureFixture):
+    """ Test that tries to release a project and seeting up as available"""
+
+    # Create mocker    
+    with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json=returned_response_get_info)
+        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_available_ok)
+
+        with project_status.ProjectStatusManager(
+            project=project_name, no_prompt=True, authenticate=False
+        ) as status_mngr:
+            status_mngr.token = {}  # required, otherwise none
+            status_mngr.update_status(new_status="Available")
+
+        assert returned_response_available_ok['message'] in capsys.readouterr().out
+
+    
+def test_archive_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
+    """Test that tries to archive/delete a project, but the user selects no to perfrom the operation"""
+
+    caplog.set_level(logging.INFO)
+    # Create mocker    
+    with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json={"project_info": returned_response_get_info})
+        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json={})
+        monkeypatch.setattr('rich.prompt.Confirm.ask', lambda question: False)
+
+        # capture system exit on not accepting operation
+        with pytest.raises(SystemExit):
+            with project_status.ProjectStatusManager(
+                project=project_name, no_prompt=True, authenticate=False
+            ) as status_mngr:
+                status_mngr.token = {}  # required, otherwise none
+                status_mngr.update_status(new_status="Archived")
+
+        captured_output = capsys.readouterr().out
+        captured_output = captured_output.split("\n")
+
+        assert f"Are you sure you want to modify the status of {project_name}? All its contents will be deleted!" in captured_output[0]
+        assert f"Title:  {returned_response_get_info['Title']}" in captured_output[2]
+        assert f"Description:    {returned_response_get_info['Description']}" in captured_output[3]
+        assert f"PI:     {returned_response_get_info['PI']}" in captured_output[4]
+
+        assert (
+            "dds_cli.project_status",
+            logging.INFO,
+            "Probably for the best. Exiting.",
+        ) in caplog.record_tuples
+
+def test_archive_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCaptureFixture):
+    """Test that tries to archive/delete a project, the user accepts the operation"""
+
+    # Create mocker    
+    with Mocker() as mock:
+        # Create mocked request - real request not executed
+        mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json={"project_info": returned_response_get_info})
+        mock.post(DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_archived_ok)
+        monkeypatch.setattr('rich.prompt.Confirm.ask', lambda question: True)
+
+        with project_status.ProjectStatusManager(
+            project=project_name, no_prompt=True, authenticate=False
+        ) as status_mngr:
+            status_mngr.token = {}  # required, otherwise none
+            status_mngr.update_status(new_status="Archived")
+
+        assert returned_response_archived_ok['message'] in capsys.readouterr().out

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -15,6 +15,11 @@ import typing
 
 project_name = "Test"
 returned_response_get_info: typing.Dict = {
+    "Project ID": "Test001",
+    "Created by": "Mr Bean",
+    "Status": "In progress",
+    "Last updated": "None",
+    "Size": "0.0 B",
     "Title": "Test",
     "Description": "a description",
     "PI": "pi@a.se",
@@ -62,11 +67,17 @@ def perform_archive_delete_operation(new_status, confirmed, mock):
 
 
 def check_output_project_info(new_status, captured_output, caplog_tuples=None):
-    assert f"The project '{project_name}' is about to be {new_status}." in captured_output.out
-    assert f"Title:  {returned_response_get_info['Title']}" in captured_output.out
-    assert f"Description:    {returned_response_get_info['Description']}" in captured_output.out
-    assert f"PI:     {returned_response_get_info['PI']}" in captured_output.out
 
+    assert f"The project {project_name} is about to be {new_status}." in captured_output.out
+
+    assert "┏━━━━━" in captured_output.out  # A table has generated
+    assert f"{returned_response_get_info['Project ID']}" in captured_output.out
+    assert f"{returned_response_get_info['Created by']}" in captured_output.out
+    assert f"{returned_response_get_info['Status']}" in captured_output.out
+    assert f"{returned_response_get_info['Last updated']}" in captured_output.out
+    assert f"{returned_response_get_info['Size']}" in captured_output.out
+
+    # if not confirmed operation
     if caplog_tuples:
         assert (
             "dds_cli.project_status",
@@ -158,10 +169,8 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
         perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
-        # for some reason the captured log includees line break here. But in the client it displays normal ->
-        # could be because of the if-else to build this log
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents and \nmetainfo will be deleted!"
+            f"Are you sure you want to modify the status of {project_name}? All its contents and metainfo will be deleted!"
             in captured_output.out
         )
 
@@ -185,10 +194,8 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
         perform_archive_delete_operation(new_status="Archived", confirmed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
-        # for some reason the captured log includees line break here. But in the client it displays normal ->
-        # could be because of the if-else to build this log
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents will be \ndeleted!"
+            f"Are you sure you want to modify the status of {project_name}? All its contents will be deleted!"
             in captured_output.out
         )
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -26,7 +26,7 @@ returned_response_archived_ok: typing.Dict = {
 #########
 
 
-def perform_archive_delete_operation(new_status, confimed):
+def perform_archive_delete_operation(new_status, confimed, mock):
 
     returned_response: typing.Dict = {
         "message": f"{project_name} updated to status {new_status}. An e-mail notification has been sent."
@@ -139,7 +139,7 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
 
         # set confirmation object to false
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed)
+        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
         # for some reason the captured log includees line break here. But in the client it displays normal ->
@@ -213,7 +213,7 @@ def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
 
         # set confirmation object to true
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed)
+        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed, mock=mock)
         assert returned_response_deleted_ok["message"] in capsys.readouterr().out
 
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -67,7 +67,6 @@ def perform_archive_delete_operation(new_status, confirmed, mock):
 
 
 def check_output_project_info(new_status, captured_output, caplog_tuples=None):
-
     assert f"The project {project_name} is about to be {new_status}." in captured_output.out
 
     assert "┏━━━━━" in captured_output.out  # A table has generated
@@ -169,8 +168,10 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
         perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
+        # for some reason the captured log includees line break here. But in the client it displays normal ->
+        # could be because of the if-else to build this log
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents and metainfo will be deleted!"
+            f"Are you sure you want to modify the status of {project_name}? All its contents and \nmetainfo will be deleted!"
             in captured_output.out
         )
 
@@ -194,8 +195,10 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
         perform_archive_delete_operation(new_status="Archived", confirmed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
+        # for some reason the captured log includees line break here. But in the client it displays normal ->
+        # could be because of the if-else to build this log
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents will be deleted!"
+            f"Are you sure you want to modify the status of {project_name}? All its contents will be \ndeleted!"
             in captured_output.out
         )
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -26,8 +26,7 @@ returned_response_archived_ok: typing.Dict = {
 #########
 
 
-def perform_archive_delete_operation(new_status, confimed, mock):
-
+def perform_archive_delete_operation(new_status, confirmed, mock):
     returned_response: typing.Dict = {
         "message": f"{project_name} updated to status {new_status}. An e-mail notification has been sent."
     }
@@ -117,7 +116,9 @@ def test_release_project(capsys: CaptureFixture):
         # Create mocked request - real request not executed
         mock.get(DDSEndpoint.PROJ_INFO, status_code=200, json={})
         mock.post(
-            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_available_ok
+            DDSEndpoint.UPDATE_PROJ_STATUS,
+            status_code=200,
+            json=returned_response_available_ok,
         )
 
         with project_status.ProjectStatusManager(
@@ -136,10 +137,9 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
     caplog.set_level(logging.INFO)
     # Create mocker
     with Mocker() as mock:
-
         # set confirmation object to false
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed, mock=mock)
+        perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
         # for some reason the captured log includees line break here. But in the client it displays normal ->
@@ -210,10 +210,9 @@ def test_delete_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
     confirmed = True
     # Create mocker
     with Mocker() as mock:
-
         # set confirmation object to true
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-        perform_archive_delete_operation(new_status="Deleted", confimed=confirmed, mock=mock)
+        perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
         assert returned_response_deleted_ok["message"] in capsys.readouterr().out
 
 
@@ -229,7 +228,9 @@ def test_archive_project_yes(capsys: CaptureFixture, monkeypatch, caplog: LogCap
             json={"project_info": returned_response_get_info},
         )
         mock.post(
-            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_archived_ok
+            DDSEndpoint.UPDATE_PROJ_STATUS,
+            status_code=200,
+            json=returned_response_archived_ok,
         )
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 
@@ -254,7 +255,9 @@ def test_update_extra_params(capsys: CaptureFixture, monkeypatch, caplog: LogCap
             json={"project_info": returned_response_get_info},
         )
         mock.post(
-            DDSEndpoint.UPDATE_PROJ_STATUS, status_code=200, json=returned_response_archived_ok
+            DDSEndpoint.UPDATE_PROJ_STATUS,
+            status_code=200,
+            json=returned_response_archived_ok,
         )
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: True)
 

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -129,7 +129,7 @@ def test_delete_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCaptu
         # for some reason the captured log includees line break here. But in the client it displays normal ->
         # could be because of the if-else to build this log
         assert (
-            f"Are you sure you want to modify the status of {project_name}? All its contents and \nmetainfo will be \ndeleted!"
+            f"Are you sure you want to modify the status of {project_name}? All its contents and \nmetainfo will be deleted!"
             in captured_output.out
         )
         assert "The project 'Test' is about to be Deleted." in captured_output.out

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -172,7 +172,7 @@ def test_archive_project_no(capsys: CaptureFixture, monkeypatch, caplog: LogCapt
     with Mocker() as mock:
         # set confirmation object to false
         monkeypatch.setattr("rich.prompt.Confirm.ask", lambda question: confirmed)
-        perform_archive_delete_operation(new_status="Deleted", confirmed=confirmed, mock=mock)
+        perform_archive_delete_operation(new_status="Archived", confirmed=confirmed, mock=mock)
         captured_output = capsys.readouterr()
 
         # for some reason the captured log includees line break here. But in the client it displays normal ->


### PR DESCRIPTION
## Before submitting this PR

1. **Description:** When deleting or achiving a project a message is printed with the project information before asking for confirmation.

2. **Jira task / GitHub issue:** https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1401
3. **How to test:** dds_cli project status archive -p project_1 and then you should be able to see the information of the project and a confirmation prompt
4. **Type of change:** [_Check the relevant boxes in the section below_](#what-type-of-changes-does-the-pr-contain)
5. **Add docstrings and comments to code**, _even if_ you personally think it's obvious.

## What _type of change(s)_ does the PR contain?

<!--
- "Breaking": The change will cause existing functionality to not work as expected.
- Workflow: E.g. a new github action or changes to this PR template. Anything that alters our or the codes workflow.
-->

- [x] New feature
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [x] Non-breaking
- [ ] Bug fix
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [ ] Non-breaking
- [ ] Security Alert fix
- [ ] Documentation
- [ ] Tests **(only)**
- [ ] Workflow

## Checklist

- [Sprintlog](../SPRINTLOG.md)
  - [x] Added
  - [ ] Not needed (E.g. PR contains _only_ tests)
- Rebase / Update / Merge _from_ base branch (the branch from which the current is forked)
  - [ ] Done
  - [ ] Not needed
- Blocking PRs
  - [ ] Merged
  - [x] No blocking PRs
- PR to `master` branch
  - [ ] Yes: Read [the release instructions](../docs/procedures/new_release.md)
    - [ ] I have followed steps 1-7.
  - [x] No

## Actions / Scans

<!-- Go through all checkboxes. All actions must pass before merging is allowed.-->

- **Black**: Python code formatter. Does not execute. Only tests.
  Run `black .` locally to execute formatting.
  - [x] Passed
- **Pylint**: Python code linter. Does not execute. Only tests.
  Fix code producing warnings. Code must get 10/10.
  - [ ] Warnings fixed
  - [x] Passed
- **Prettier**: General code formatter. Our use case: MD and yaml mainly.
  Run `npx prettier --write .` locally to execute formatting.
  - [x] Passed
- **Yamllint**: Linting of yaml files.
  - [x] Passed
- **Tests**: Pytest to verify that functionality works as expected.
  - [ ] New tests added
  - [x] No new tests
  - [x] Passed
- **TestPyPi**: Build CLI and publish to TestPyPi in order to verify before release.
  - [x] Passed
- **CodeQL**: Scan for security vulnerabilities, bugs, errors
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Trivy**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Snyk**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
