### PR TITLE
Catch ApiRequestError in update_db 

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -305,6 +305,7 @@ _Nothing merged in CLI during this sprint_
 
 # 2023-10-16 - 2023-10-27
 
-- Change "Checksum verification successful. File integrity verified." logging level from INFO to DEBUG in order to not print for all files ([#662](https://github.com/ScilifelabDataCentre/dds_cli/pull/662)
-- New command `dds project status extend` to allow extension of project deadline ([#661](https://github.com/ScilifelabDataCentre/dds_cli/pull/661)
+- Change "Checksum verification successful. File integrity verified." logging level from INFO to DEBUG in order to not print for all files ([#662](https://github.com/ScilifelabDataCentre/dds_cli/pull/662))
+- New command `dds project status extend` to allow extension of project deadline ([#661](https://github.com/ScilifelabDataCentre/dds_cli/pull/661))
 - New version: 2.5.2 ([#660](https://github.com/ScilifelabDataCentre/dds_cli/pull/660))
+- Catch `ApiRequestError` in `update_db` in order to get more error information ([#663](https://github.com/ScilifelabDataCentre/dds_cli/pull/663))

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -221,15 +221,20 @@ class DataGetter(base.DDSBaseClass):
         params = {"project": self.project}
 
         # Send file info to API
-        response_json, _ = dds_cli.utils.perform_request(
-            DDSEndpoint.FILE_UPDATE,
-            method="put",
-            params=params,
-            json=filename,
-            headers=self.token,
-            error_message="Failed to update file information",
-        )
-
-        updated_in_db, message = (True, response_json["message"])
+        try:
+            response_json, _ = dds_cli.utils.perform_request(
+                DDSEndpoint.FILE_UPDATE,
+                method="put",
+                params=params,
+                json=filename,
+                headers=self.token,
+                error_message="Failed to update file information",
+            )
+        except dds_cli.exceptions.ApiRequestError as err:
+            updated_in_db = False
+            message = str(err)
+        else:
+            updated_in_db = True
+            message = response_json["message"]
 
         return updated_in_db, message

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -5,7 +5,7 @@ import pathlib
 import typing
 import http
 from typing import Dict, List, Union
-import logging 
+import logging
 
 import requests
 import rich.console

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -192,8 +192,6 @@ def perform_request(
             timeout=timeout,
         )
         response_json = response.json()
-        if endpoint == DDSEndpoint.FILE_UPDATE:
-            raise requests.exceptions.RequestException
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(
             message=(

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -5,7 +5,6 @@ import pathlib
 import typing
 import http
 from typing import Dict, List, Union
-import logging
 
 import requests
 import rich.console
@@ -193,6 +192,8 @@ def perform_request(
             timeout=timeout,
         )
         response_json = response.json()
+        if endpoint == DDSEndpoint.FILE_UPDATE:
+            raise requests.exceptions.RequestException
     except simplejson.JSONDecodeError as err:
         raise dds_cli.exceptions.ApiResponseError(
             message=(

--- a/dds_cli/utils.py
+++ b/dds_cli/utils.py
@@ -5,6 +5,7 @@ import pathlib
 import typing
 import http
 from typing import Dict, List, Union
+import logging 
 
 import requests
 import rich.console
@@ -201,11 +202,11 @@ def perform_request(
         )
     except requests.exceptions.RequestException as err:
         if isinstance(err, requests.exceptions.ConnectionError):
-            error_message += ": The database seems to be down."
+            error_message += f": The database seems to be down -- \n{err}"
         elif isinstance(err, requests.exceptions.Timeout):
             error_message += ": The request timed out."
         else:
-            error_message += f": Unknown request error -- \n {err}"
+            error_message += f": Unknown request error -- \n{err}"
         raise dds_cli.exceptions.ApiRequestError(message=error_message)
 
     # Get and parse project specific errors

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,7 +188,7 @@ def test_perform_request_request_exception() -> None:
         )
 
     assert len(exc_info.value.args) == 1
-    assert exc_info.value.args[0] == "API Request failed.: The database seems to be down."
+    assert "API Request failed.: The database seems to be down." in exc_info.value.args[0]
 
 
 def test_perform_request_api_response_error_internal_server_error() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,7 +188,7 @@ def test_perform_request_request_exception() -> None:
         )
 
     assert len(exc_info.value.args) == 1
-    assert "API Request failed.: The database seems to be down." in exc_info.value.args[0]
+    assert "API Request failed.: The database seems to be down" in exc_info.value.args[0]
 
 
 def test_perform_request_api_response_error_internal_server_error() -> None:


### PR DESCRIPTION
## Read this before submitting the PR

1. Always create a Draft PR first
2. Go through sections 1-5 below, fill them in and check all the boxes
3. Make sure that the branch is updated; if there's an "Update branch" button at the bottom of the PR, rebase or update branch.
4. When all boxes are checked, information is filled in, and the branch is updated: mark as Ready For Review and tag reviewers (top right)
5. Once there is a submitted review, implement the suggestions (if reasonable, otherwise discuss) and request an new review.

If there is a field which you are unsure about, enter the edit mode of this description or go to the [PR template](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/.github/pull_request_template.md); There are invisible comments providing descriptions which may be of help.

## 1. Description / Summary

If there is a connection error we're currently not getting the full error printed out. This changes that in order to hopefully let us debug an issue. 

## 2. Jira task / GitHub issue

X

## 3. Type of change

What _type of change(s)_ does the PR contain?

**Check the relevant boxes below. For an explanation of the different sections, enter edit mode of this PR description template.**

- [X] New feature
  - [ ] Breaking: _Why / How? Add info here._ <!-- Should be checked if the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli` -->
  - [X] Non-breaking <!-- Should be checked if the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- [ ] Database change: _Remember the to include a new migration version, **or** explain here why it's not needed._ <!-- Should be checked when you've changed something in `models.py`. For a guide on how to add the a new migration version, look at the "Database changes" section in the README.md. -->
- [ ] Bug fix <!-- Should be checked when a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- [ ] Security Alert fix <!-- Should be checked if the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
- [ ] Documentation <!-- Should be checked if the PR adds or updates the CLI documentation -- anything in docs/ directory. -->
- [ ] Workflow <!-- Should be checked if the PR includes a change in e.g. the github actions files (dds_cli/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- [ ] Tests **only** <!-- Should only be checked if the PR only contains tests, none of the other types of changes listed above. -->

## 4. Additional information

- [x] [Sprintlog](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] Blocking PRs <!-- Should be checked if there are blocking PRs or other tasks that need to be merged prior to this. Add link to PR or Jira card if this is the case. -->
  - [ ] Merged <!-- Should be checked if the "Blocking PRs" box was checked AND all blocking PRs have been merged / fixed. -->
- [ ] PR to `master` branch: _If checked, read [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)_ <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans

_Check the boxes when the specified checks have passed._

**For information on what the different checks do and how to fix it if they're failing, enter edit mode of this description or go to the [PR template](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/.github/pull_request_template.md).**

- [x] **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- [x] **Pylint**
<!--
  What: Python code linter.
  How to fix: Manually fix the code producing warnings. Code must get 10/10.
-->
- [x] **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- [x] **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- [x] **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- [x] **TestPyPI**
<!--
  What: Builds the CLI and publishes to TestPyPI in order to verify before release.
  How to fix: Check the action logs and fix potential issues manually.
-->
- [ ] **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [ ] **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
