### PR TITLE
Add 'upload' or 'download' to directory name

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -392,4 +392,4 @@ _Empty sprint_
 
 # 2024-12-02 - 2024-12-13
 
-- 'Upload' or 'Download' added to end of delivery directory name ([#726](https://github.com/ScilifelabDataCentre/dds_cli/pull/726))
+- 'Upload' or 'Download' added to end of delivery directory name depending on command ([#726](https://github.com/ScilifelabDataCentre/dds_cli/pull/726))

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -389,3 +389,7 @@ _Empty sprint_
 
 - Update MOTD command according to post merge review ([#720](https://github.com/ScilifelabDataCentre/dds_cli/pull/720))
 - New version: 2.8.1([#719](https://github.com/ScilifelabDataCentre/dds_cli/pull/719))
+
+# 2024-12-02 - 2024-12-13
+
+- 'Upload' or 'Download' added to end of delivery directory name ([#726](https://github.com/ScilifelabDataCentre/dds_cli/pull/726))

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -72,7 +72,8 @@ class DDSBaseClass:
             # Use user defined destination if any specified
             if self.method in DDS_DIR_REQUIRED_METHODS:
                 default_dir = pathlib.Path(
-                    f"DataDelivery_{dds_cli.timestamp.TimeStamp().timestamp}_{self.project}_{'upload' if self.method == 'put' else 'download'}"
+                    f"DataDelivery_{dds_cli.timestamp.TimeStamp().timestamp}_{self.project}_"
+                    f"{'upload' if self.method == 'put' else 'download'}"
                 )
                 if mount_dir:
                     new_directory = mount_dir / default_dir

--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -72,7 +72,7 @@ class DDSBaseClass:
             # Use user defined destination if any specified
             if self.method in DDS_DIR_REQUIRED_METHODS:
                 default_dir = pathlib.Path(
-                    f"DataDelivery_{dds_cli.timestamp.TimeStamp().timestamp}_{self.project}"
+                    f"DataDelivery_{dds_cli.timestamp.TimeStamp().timestamp}_{self.project}_{'upload' if self.method == 'put' else 'download'}"
                 )
                 if mount_dir:
                     new_directory = mount_dir / default_dir


### PR DESCRIPTION
## Read this before submitting the PR

1. Always create a Draft PR first
2. Go through sections 1-5 below, fill them in and check all the boxes
3. Make sure that the branch is updated; if there's an "Update branch" button at the bottom of the PR, rebase or update branch.
4. When all boxes are checked, information is filled in, and the branch is updated: mark as Ready For Review and tag reviewers (top right)
5. Once there is a submitted review, implement the suggestions (if reasonable, otherwise discuss) and request an new review.

If there is a field which you are unsure about, enter the edit mode of this description or go to the [PR template](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/.github/pull_request_template.md); There are invisible comments providing descriptions which may be of help.

## 1. Description / Summary

This PR adds 'upload' if `dds data put'  is run and 'download' if `dds data get` is run, to the name of the directory that is generated to store staging files and logs.

## 2. Jira task / GitHub issue

[HMS-2090](https://scilifelab.atlassian.net/jira/software/projects/HMS/boards/13?selectedIssue=HMS-2090)

## 3. Type of change

What _type of change(s)_ does the PR contain?

**Check the relevant boxes below. For an explanation of the different sections, enter edit mode of this PR description template.**

- [x] New feature
  - [ ] Breaking: _Why / How? Add info here._ <!-- Should be checked if the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli` -->
  - [ ] Non-breaking <!-- Should be checked if the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- [ ] Bug fix <!-- Should be checked when a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- [ ] Security Alert fix <!-- Should be checked if the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
  - [ ] Package update <!-- Should be checked if the Security alert fix consists of updating a package / dependency version -->
    - [ ] Major version update <!-- Should be checked if the package / dependency version update is a major upgrade, e.g. 1.0.0 to 2.0.0 -->
- [ ] Documentation <!-- Should be checked if the PR adds or updates the CLI documentation -- anything in docs/ directory. -->
- [ ] Workflow <!-- Should be checked if the PR includes a change in e.g. the github actions files (dds_cli/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- [ ] Tests **only** <!-- Should only be checked if the PR only contains tests, none of the other types of changes listed above. -->

## 4. Additional information

- [x] [Sprintlog](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] Blocking PRs <!-- Should be checked if there are blocking PRs or other tasks that need to be merged prior to this. Add link to PR or Jira card if this is the case. -->
  - [ ] Merged <!-- Should be checked if the "Blocking PRs" box was checked AND all blocking PRs have been merged / fixed. -->
- [ ] PR to `master` branch: _If checked, read [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)_ <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans

_Check the boxes when the specified checks have passed._

**For information on what the different checks do and how to fix it if they're failing, enter edit mode of this description or go to the [PR template](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/.github/pull_request_template.md).**

- [x] **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- [x] **Pylint**
<!--
  What: Python code linter.
  How to fix: Manually fix the code producing warnings. Code must get 10/10.
-->
- [x] **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- [x] **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- [x] **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- [x] **TestPyPI**
<!--
  What: Builds the CLI and publishes to TestPyPI in order to verify before release.
  How to fix: Check the action logs and fix potential issues manually.
-->
- [x] **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->


[HMS-2090]: https://scilifelab.atlassian.net/browse/HMS-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ