### PR TITLE
Corrupt file check - file size check

### DIFF
--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -146,7 +146,9 @@ class DataGetter(base.DDSBaseClass):
                 file_size_check = True
                 LOG.debug(f"Downloaded file size matches expected size: {expected_size} bytes.")
             else:
-                LOG.debug(f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes")
+                LOG.debug(
+                    f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes"
+                )
 
         if file_size_check:
             db_updated, message = self.update_db(file=file)
@@ -180,7 +182,9 @@ class DataGetter(base.DDSBaseClass):
                 if actual_size == expected_size:
                     LOG.debug(f"Downloaded file size matches expected size: {expected_size} bytes.")
                 else:
-                    LOG.debug(f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes")
+                    LOG.debug(
+                        f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes"
+                    )
                 # TODO (ina): decide on checksum verification method --
                 # this checks original, the other is generated from compressed
                 all_ok, message = (

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -149,7 +149,7 @@ class DataGetter(base.DDSBaseClass):
                 LOG.debug(
                     "Downloaded file size mismatch: expected %s bytes, got %s bytes",
                     expected_size,
-                    actual_size
+                    actual_size,
                 )
 
         if file_size_check:
@@ -182,12 +182,14 @@ class DataGetter(base.DDSBaseClass):
                 expected_size = file_info["size_original"]
                 actual_size = pathlib.Path(file).stat().st_size
                 if actual_size == expected_size:
-                    LOG.debug("Downloaded file size matches expected size: %s bytes.", expected_size)
+                    LOG.debug(
+                        "Downloaded file size matches expected size: %s bytes.", expected_size
+                    )
                 else:
                     LOG.debug(
                         "Downloaded file size mismatch: expected %s bytes, got %s bytes",
                         expected_size,
-                        actual_size
+                        actual_size,
                     )
                 # TODO (ina): decide on checksum verification method --
                 # this checks original, the other is generated from compressed

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -144,10 +144,12 @@ class DataGetter(base.DDSBaseClass):
 
             if actual_size == expected_size:
                 file_size_check = True
-                LOG.debug(f"Downloaded file size matches expected size: {expected_size} bytes.")
+                LOG.debug("Downloaded file size matches expected size: %s bytes.", expected_size)
             else:
                 LOG.debug(
-                    f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes"
+                    "Downloaded file size mismatch: expected %s bytes, got %s bytes",
+                    expected_size,
+                    actual_size
                 )
 
         if file_size_check:
@@ -180,10 +182,12 @@ class DataGetter(base.DDSBaseClass):
                 expected_size = file_info["size_original"]
                 actual_size = pathlib.Path(file).stat().st_size
                 if actual_size == expected_size:
-                    LOG.debug(f"Downloaded file size matches expected size: {expected_size} bytes.")
+                    LOG.debug("Downloaded file size matches expected size: %s bytes.", expected_size)
                 else:
                     LOG.debug(
-                        f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes"
+                        "Downloaded file size mismatch: expected %s bytes, got %s bytes",
+                        expected_size,
+                        actual_size
                     )
                 # TODO (ina): decide on checksum verification method --
                 # this checks original, the other is generated from compressed

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -144,9 +144,9 @@ class DataGetter(base.DDSBaseClass):
 
             if actual_size == expected_size:
                 file_size_check = True
-                message = f"Downloaded file size matches expected size: {expected_size} bytes."
+                LOG.debug(f"Downloaded file size matches expected size: {expected_size} bytes.")
             else:
-                message = f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes"
+                LOG.debug(f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes")
 
         if file_size_check:
             db_updated, message = self.update_db(file=file)
@@ -174,6 +174,13 @@ class DataGetter(base.DDSBaseClass):
 
             LOG.debug("File saved? %s", file_saved)
             if file_saved:
+                # Check file size post-decryption and post-decompression
+                expected_size = file_info["size_original"]
+                actual_size = pathlib.Path(file).stat().st_size
+                if actual_size == expected_size:
+                    LOG.debug(f"Downloaded file size matches expected size: {expected_size} bytes.")
+                else:
+                    LOG.debug(f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes")
                 # TODO (ina): decide on checksum verification method --
                 # this checks original, the other is generated from compressed
                 all_ok, message = (

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -135,7 +135,20 @@ class DataGetter(base.DDSBaseClass):
 
         LOG.debug("File '%s' downloaded: %s", escape(str(file)), file_downloaded)
 
+        file_size_check = False
+
         if file_downloaded:
+            ## File size verification
+            expected_size = file_info["size_stored"]
+            actual_size = file_info["path_downloaded"].stat().st_size
+
+            if actual_size == expected_size:
+                file_size_check = True
+                message = f"Downloaded file size matches expected size: {expected_size} bytes."
+            else:
+                message = f"Downloaded file size mismatch: expected {expected_size} bytes, got {actual_size} bytes"
+
+        if file_size_check:
             db_updated, message = self.update_db(file=file)
             LOG.debug("Database updated: %s", db_updated)
 


### PR DESCRIPTION
## 1. Description

There appear to be many errors in the log related to file corruption and integrity issues, that is before file decryption starts. One cause might be a truncated file that was not completely downloaded. This PR adds some code to verify file size.

- [x] Run locally
