### PR TITLE
Handle KeyboardInterrupt when cancelling file

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -447,3 +447,7 @@ _Empty sprint_
 - Add ARD's for GUI
 - Refactor MOTD to work for both the CLI and the GUI ([#771](https://github.com/ScilifelabDataCentre/dds_cli/pull/771))
 - Implement MOTD for GUI ([#772](https://github.com/ScilifelabDataCentre/dds_cli/pull/772))
+
+# 2025-08-18 - 2025-08-29
+
+- Bug: Add missing f-string to logging when cancelling file with KeyboardInterrupt ([#777](https://github.com/ScilifelabDataCentre/dds_cli/pull/777))

--- a/dds_cli/custom_decorators.py
+++ b/dds_cli/custom_decorators.py
@@ -40,7 +40,7 @@ def verify_proceed(func):
         # Check if keyboardinterrupt in dds
         if self.stop_doing:
             # TODO (ina): Add save to status here
-            message = "KeyBoardInterrupt - cancelling file {escape(file)}"
+            message = f"KeyboardInterrupt - cancelling file {escape(file)}"
             LOG.warning(message)
             return False  # Do not proceed
 


### PR DESCRIPTION
## Summary

@i-oden Is playing around with ChatGPT and trying to use it to find bugs.

- Use f-string when logging cancellation due to KeyboardInterrupt

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyfakefs')*


------
https://chatgpt.com/codex/tasks/task_b_68a709f8e9a88326a267ae7888f07641