### PR TITLE
docs: fix black badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <a href="https://opensource.org/licenses/MIT">
     <img alt="Licence: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg">
 </a>
-<a href="[https://opensource.org/licenses/MIT](https://github.com/psf/black)">
+<a href="https://github.com/psf/black">
     <img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg">
 </a>
 <a href="https://prettier.io/">


### PR DESCRIPTION
## Summary
- fix README black badge link to point directly to psf/black

## Testing
- `curl -I https://img.shields.io/badge/code%20style-black-000000.svg` (fails: CONNECT tunnel failed, 403)
- `curl -I https://github.com/psf/black` (fails: CONNECT tunnel failed, 403)
- `pip install pyfakefs requests_mock flask` (fails: Tunnel connection failed: 403)
- `pytest` (fails: ModuleNotFoundError: No module named 'pyfakefs')

------
https://chatgpt.com/codex/tasks/task_b_68a70a50a7b483269084d972c38eed2b