### PR TITLE
Add Windows Pytest workflow

### DIFF
--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies and run tests on Windows
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+---
+name: Pytest (Windows)
+
+on:
+  push:
+
+  pull_request:
+    branches: [dev, master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dds_cli
+        run: |
+          pip install .
+
+      - name: Install test requirements
+        run: |
+          pip install -r tests/requirements-test.txt
+
+      - name: Test with pytest
+        env:
+          COVERAGE_FILE: ./coverage/.coverage
+        run: |
+          pytest --color=yes --cov=./dds_cli --cov-report=xml:coverage/report.xml
+
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/report.xml


### PR DESCRIPTION
## Summary
- add CI workflow to run pytest on Windows

## Testing
- `pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pip install -r tests/requirements-test.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*
- `COVERAGE_FILE=./coverage/.coverage pytest --color=yes --cov=./dds_cli --cov-report=xml:coverage/report.xml` *(fails: pytest: error: unrecognized arguments: --cov=./dds_cli --cov-report=xml:coverage/report.xml)*

------
https://chatgpt.com/codex/tasks/task_b_68a818d9f9148326a8cd4bddd2b57522