### PR TITLE
feat: add dedicated decryption error

### DIFF
--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -153,21 +153,25 @@ class DataGetter(base.DDSBaseClass):
                 key_salt=file_info["salt"],
                 files_directory=self.dds_directory.directories["FILES"],
             ) as decryptor:
-                streamed_chunks = decryptor.decrypt_file(
-                    infile=file_info["path_downloaded"], outfile=file
-                )
+                try:
+                    streamed_chunks = decryptor.decrypt_file(
+                        infile=file_info["path_downloaded"], outfile=file
+                    )
 
-                stream_to_file_func = (
-                    fc.Compressor.decompress_filechunks
-                    if file_info["compressed"]
-                    else self.filehandler.write_file
-                )
+                    stream_to_file_func = (
+                        fc.Compressor.decompress_filechunks
+                        if file_info["compressed"]
+                        else self.filehandler.write_file
+                    )
 
-                file_saved, message = stream_to_file_func(
-                    chunks=streamed_chunks,
-                    outfile=file,
-                    files_directory=self.dds_directory.directories["FILES"],
-                )
+                    file_saved, message = stream_to_file_func(
+                        chunks=streamed_chunks,
+                        outfile=file,
+                        files_directory=self.dds_directory.directories["FILES"],
+                    )
+                except dds_cli.exceptions.DecryptionError as err:
+                    file_saved = False
+                    message = str(err)
 
             LOG.debug("File '%s' saved? %s", file_name_in_db, file_saved)
             if file_saved:

--- a/dds_cli/exceptions.py
+++ b/dds_cli/exceptions.py
@@ -105,6 +105,10 @@ class DownloadError(Exception):
     """Errors relating to file download."""
 
 
+class DecryptionError(Exception):
+    """Errors relating to file decryption."""
+
+
 class NoDataError(Exception):
     """Errors when there is no data to do anything with."""
 

--- a/dds_cli/file_encryptor.py
+++ b/dds_cli/file_encryptor.py
@@ -23,6 +23,7 @@ from rich.markup import escape
 
 # Own modules
 from dds_cli import FileSegment
+from dds_cli.exceptions import DecryptionError
 from dds_cli.file_handler_local import LocalFileHandler as fh
 
 ###############################################################################
@@ -247,7 +248,7 @@ class Decryptor(ECDHKeyHandler):
 
                 # Decrypt file
                 if file.tell() != 12:
-                    raise SystemExit
+                    raise DecryptionError("Invalid encrypted file format")
 
                 iv_int = int.from_bytes(first_nonce, "little")
                 aad = None
@@ -273,6 +274,9 @@ class Decryptor(ECDHKeyHandler):
                     nonce,
                 )
                 if last_nonce != nonce:
-                    raise SystemExit("Nonces do not match!!")
+                    raise DecryptionError("Nonces do not match!!")
+        except DecryptionError as err:
+            LOG.warning(str(err))
+            raise
         except Exception as err:  # pylint: disable=broad-exception-caught
             LOG.warning(str(err))


### PR DESCRIPTION
## Summary
- add DecryptionError exception for decryption issues
- replace SystemExit with DecryptionError in Decryptor
- catch decryption errors during data retrieval

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyfakefs')*
- `pip install pyfakefs requests_mock` *(fails: Could not find a version that satisfies the requirement pyfakefs)*
- `python -m py_compile dds_cli/file_encryptor.py dds_cli/exceptions.py dds_cli/data_getter.py`


------
https://chatgpt.com/codex/tasks/task_b_68a818050a408326b16b29f7983db801