### PR TITLE
Raise ApiResponseError for missing S3 info

### DIFF
--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -160,7 +160,12 @@ class DDSBaseClass:
     # Private methods ############################### Private methods #
     def __get_safespring_keys(self):
         """Get safespring keys."""
-        return s3.S3Connector(project_id=self.project, token=self.token)
+        try:
+            return s3.S3Connector(project_id=self.project, token=self.token)
+        except exceptions.ApiResponseError as err:
+            raise exceptions.ApiResponseError(
+                message=f"Failed to retrieve cloud access information: {err}"
+            ) from err
 
     def __get_project_keys(self):
         """Get public and private project keys depending on method."""

--- a/dds_cli/s3_connector.py
+++ b/dds_cli/s3_connector.py
@@ -16,6 +16,7 @@ import botocore
 # Own modules
 import dds_cli.utils
 from dds_cli import DDSEndpoint
+from dds_cli import exceptions
 
 ###############################################################################
 # LOGGING ########################################################### LOGGING #
@@ -105,6 +106,8 @@ class S3Connector:
             s3info.get("bucket"),
         )
         if None in [safespring_project, keys, url, bucket]:
-            raise SystemExit("Missing safespring information in response.")  # TODO: change
+            raise exceptions.ApiResponseError(
+                "Missing safespring information in response."
+            )
 
         return safespring_project, keys, url, bucket


### PR DESCRIPTION
## Summary
- raise ApiResponseError when S3 information from API is incomplete
- catch S3 info errors in DDSBaseClass and re-raise with user-friendly message

## Testing
- `pytest tests/test_account_manager.py::TestAccountManager -q` *(fails: ModuleNotFoundError: No module named 'pyfakefs')*


------
https://chatgpt.com/codex/tasks/task_b_68a8180723288326ae2229235375a32d