### PR TITLE
test: use dynamic file path in compressor error log

### DIFF
--- a/tests/test_file_compressor.py
+++ b/tests/test_file_compressor.py
@@ -25,7 +25,7 @@ def test_compress_file_nonexistent(fs: FakeFilesystem, caplog: LogCaptureFixture
         assert (
             "dds_cli.file_compressor",
             logging.WARNING,
-            f"[Errno 2] No such file or directory in the fake filesystem: 'nonexistentfile.txt'",
+            f"[Errno 2] No such file or directory in the fake filesystem: '{non_existent_file}'",
         ) in caplog.record_tuples
         assert (
             "dds_cli.file_compressor",


### PR DESCRIPTION
## Summary
- expect compressor error log to include actual file path

## Testing
- `pytest tests/test_file_compressor.py::test_compress_file_nonexistent -q` *(fails: ModuleNotFoundError: No module named 'pyfakefs')*
- `pip install pyfakefs` *(fails: Could not find a version that satisfies the requirement pyfakefs)*

------
https://chatgpt.com/codex/tasks/task_b_68a82b85badc83268b2cc946ef3cc2da