### PR TITLE
Refactor LocalFileHandler tests to use pathlib paths

### DIFF
--- a/tests/test_file_handler_local.py
+++ b/tests/test_file_handler_local.py
@@ -23,7 +23,9 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
     # Verify files exist
     assert fs.exists(file_path=pathlib.Path("parentdir") / "fileinparentdir.file")
     assert fs.exists(file_path=pathlib.Path("parentdir") / "somedir" / "fileinsomedir.file")
-    assert fs.exists(file_path=pathlib.Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
+    assert fs.exists(
+        file_path=pathlib.Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file"
+    )
 
     # Verify that fails with incorrect paths
     assert not fs.exists(file_path=pathlib.Path("anotherdir"))
@@ -51,7 +53,9 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "overwrite": False,
             "checksum": "",
         },
-        (pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file").as_posix(): {
+        (
+            pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file"
+        ).as_posix(): {
             "path_raw": pathlib.Path.cwd() / "parentdir" / "somedir" / "fileinsomedir.file",
             "subpath": pathlib.Path("remote_destination") / "parentdir" / "somedir",
             "size_raw": 0,
@@ -66,9 +70,17 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "checksum": "",
         },
         (
-            pathlib.Path("remote_destination") / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file"
+            pathlib.Path("remote_destination")
+            / "parentdir"
+            / "somedir"
+            / "subdir"
+            / "fileinsubdir.file"
         ).as_posix(): {
-            "path_raw": pathlib.Path.cwd() / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file",
+            "path_raw": pathlib.Path.cwd()
+            / "parentdir"
+            / "somedir"
+            / "subdir"
+            / "fileinsubdir.file",
             "subpath": pathlib.Path("remote_destination") / "parentdir" / "somedir" / "subdir",
             "size_raw": 0,
             "compressed": False,

--- a/tests/test_file_handler_local.py
+++ b/tests/test_file_handler_local.py
@@ -1,4 +1,4 @@
-import pathlib
+from pathlib import Path
 from pyfakefs.fake_filesystem import FakeFilesystem
 from dds_cli.file_handler_local import LocalFileHandler
 
@@ -6,73 +6,80 @@ from dds_cli.file_handler_local import LocalFileHandler
 def test_localfilehandler_with_destination(fs: FakeFilesystem):
     """Test that the destination flag works."""
     # Create directories
-    fs.create_dir("parentdir")
-    fs.create_dir("parentdir/somedir")
-    fs.create_dir("parentdir/somedir/subdir")
+    fs.create_dir(Path("parentdir"))
+    fs.create_dir(Path("parentdir") / "somedir")
+    fs.create_dir(Path("parentdir") / "somedir" / "subdir")
 
     # Verify exists
-    assert fs.exists(file_path="parentdir")
-    assert fs.exists(file_path="parentdir/somedir")
-    assert fs.exists(file_path="parentdir/somedir/subdir")
+    assert fs.exists(file_path=Path("parentdir"))
+    assert fs.exists(file_path=Path("parentdir") / "somedir")
+    assert fs.exists(file_path=Path("parentdir") / "somedir" / "subdir")
 
     # Create files
-    fs.create_file("parentdir/fileinparentdir.file")
-    fs.create_file("parentdir/somedir/fileinsomedir.file")
-    fs.create_file("parentdir/somedir/subdir/fileinsubdir.file")
+    fs.create_file(Path("parentdir") / "fileinparentdir.file")
+    fs.create_file(Path("parentdir") / "somedir" / "fileinsomedir.file")
+    fs.create_file(Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
 
     # Verify files exist
-    assert fs.exists(file_path="parentdir/fileinparentdir.file")
-    assert fs.exists(file_path="parentdir/somedir/fileinsomedir.file")
-    assert fs.exists(file_path="parentdir/somedir/subdir/fileinsubdir.file")
+    assert fs.exists(file_path=Path("parentdir") / "fileinparentdir.file")
+    assert fs.exists(file_path=Path("parentdir") / "somedir" / "fileinsomedir.file")
+    assert fs.exists(file_path=Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
 
     # Verify that fails with incorrect paths
-    assert not fs.exists(file_path="anotherdir")
-    assert not fs.exists(file_path="parentdir/somefile.file")
+    assert not fs.exists(file_path=Path("anotherdir"))
+    assert not fs.exists(file_path=Path("parentdir") / "somefile.file")
 
     # Call LocalFileHandler
     filehandler = LocalFileHandler(
-        user_input=((pathlib.Path("parentdir"),), None),
+        user_input=((Path("parentdir"),), None),
         project="someproject",
         temporary_destination="temporarydestination",
         remote_destination="remote_destination",
     )
     expected_data_1 = {
-        "remote_destination/parentdir/fileinparentdir.file": {
-            "path_raw": pathlib.Path("/parentdir/fileinparentdir.file"),
-            "subpath": pathlib.Path("remote_destination/parentdir/"),
+        (Path("remote_destination") / "parentdir" / "fileinparentdir.file").as_posix(): {
+            "path_raw": Path.cwd() / "parentdir" / "fileinparentdir.file",
+            "subpath": Path("remote_destination") / "parentdir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
-                raw_file=pathlib.Path("parentdir/fileinparentdir.file"),
-                subpath=pathlib.Path("remote_destination/parentdir"),
+                raw_file=Path("parentdir") / "fileinparentdir.file",
+                subpath=Path("remote_destination") / "parentdir",
                 no_compression=False,
             ),
             "size_processed": 0,
             "overwrite": False,
             "checksum": "",
         },
-        "remote_destination/parentdir/somedir/fileinsomedir.file": {
-            "path_raw": pathlib.Path("/parentdir/somedir/fileinsomedir.file"),
-            "subpath": pathlib.Path("remote_destination/parentdir/somedir/"),
+        (Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file").as_posix(): {
+            "path_raw": Path.cwd() / "parentdir" / "somedir" / "fileinsomedir.file",
+            "subpath": Path("remote_destination") / "parentdir" / "somedir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
-                raw_file=pathlib.Path("parentdir/somedir/fileinsomedir.file"),
-                subpath=pathlib.Path("remote_destination/parentdir/somedir"),
+                raw_file=Path("parentdir") / "somedir" / "fileinsomedir.file",
+                subpath=Path("remote_destination") / "parentdir" / "somedir",
                 no_compression=False,
             ),
             "size_processed": 0,
             "overwrite": False,
             "checksum": "",
         },
-        "remote_destination/parentdir/somedir/subdir/fileinsubdir.file": {
-            "path_raw": pathlib.Path("/parentdir/somedir/subdir/fileinsubdir.file"),
-            "subpath": pathlib.Path("remote_destination/parentdir/somedir/subdir/"),
+        (Path("remote_destination") / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file").as_posix(): {
+            "path_raw": Path.cwd()
+            / "parentdir"
+            / "somedir"
+            / "subdir"
+            / "fileinsubdir.file",
+            "subpath": Path("remote_destination") / "parentdir" / "somedir" / "subdir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
-                raw_file=pathlib.Path("parentdir/somedir/subdir/fileinsubdir.file"),
-                subpath=pathlib.Path("remote_destination/parentdir/somedir/subdir"),
+                raw_file=Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file",
+                subpath=Path("remote_destination")
+                / "parentdir"
+                / "somedir"
+                / "subdir",
                 no_compression=False,
             ),
             "size_processed": 0,

--- a/tests/test_file_handler_local.py
+++ b/tests/test_file_handler_local.py
@@ -65,21 +65,16 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "overwrite": False,
             "checksum": "",
         },
-        (Path("remote_destination") / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file").as_posix(): {
-            "path_raw": Path.cwd()
-            / "parentdir"
-            / "somedir"
-            / "subdir"
-            / "fileinsubdir.file",
+        (
+            Path("remote_destination") / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file"
+        ).as_posix(): {
+            "path_raw": Path.cwd() / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file",
             "subpath": Path("remote_destination") / "parentdir" / "somedir" / "subdir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
                 raw_file=Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file",
-                subpath=Path("remote_destination")
-                / "parentdir"
-                / "somedir"
-                / "subdir",
+                subpath=Path("remote_destination") / "parentdir" / "somedir" / "subdir",
                 no_compression=False,
             ),
             "size_processed": 0,

--- a/tests/test_file_handler_local.py
+++ b/tests/test_file_handler_local.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import pathlib
 from pyfakefs.fake_filesystem import FakeFilesystem
 from dds_cli.file_handler_local import LocalFileHandler
 
@@ -6,59 +6,59 @@ from dds_cli.file_handler_local import LocalFileHandler
 def test_localfilehandler_with_destination(fs: FakeFilesystem):
     """Test that the destination flag works."""
     # Create directories
-    fs.create_dir(Path("parentdir"))
-    fs.create_dir(Path("parentdir") / "somedir")
-    fs.create_dir(Path("parentdir") / "somedir" / "subdir")
+    fs.create_dir(pathlib.Path("parentdir"))
+    fs.create_dir(pathlib.Path("parentdir") / "somedir")
+    fs.create_dir(pathlib.Path("parentdir") / "somedir" / "subdir")
 
     # Verify exists
-    assert fs.exists(file_path=Path("parentdir"))
-    assert fs.exists(file_path=Path("parentdir") / "somedir")
-    assert fs.exists(file_path=Path("parentdir") / "somedir" / "subdir")
+    assert fs.exists(file_path=pathlib.Path("parentdir"))
+    assert fs.exists(file_path=pathlib.Path("parentdir") / "somedir")
+    assert fs.exists(file_path=pathlib.Path("parentdir") / "somedir" / "subdir")
 
     # Create files
-    fs.create_file(Path("parentdir") / "fileinparentdir.file")
-    fs.create_file(Path("parentdir") / "somedir" / "fileinsomedir.file")
-    fs.create_file(Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
+    fs.create_file(pathlib.Path("parentdir") / "fileinparentdir.file")
+    fs.create_file(pathlib.Path("parentdir") / "somedir" / "fileinsomedir.file")
+    fs.create_file(pathlib.Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
 
     # Verify files exist
-    assert fs.exists(file_path=Path("parentdir") / "fileinparentdir.file")
-    assert fs.exists(file_path=Path("parentdir") / "somedir" / "fileinsomedir.file")
-    assert fs.exists(file_path=Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
+    assert fs.exists(file_path=pathlib.Path("parentdir") / "fileinparentdir.file")
+    assert fs.exists(file_path=pathlib.Path("parentdir") / "somedir" / "fileinsomedir.file")
+    assert fs.exists(file_path=pathlib.Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file")
 
     # Verify that fails with incorrect paths
-    assert not fs.exists(file_path=Path("anotherdir"))
-    assert not fs.exists(file_path=Path("parentdir") / "somefile.file")
+    assert not fs.exists(file_path=pathlib.Path("anotherdir"))
+    assert not fs.exists(file_path=pathlib.Path("parentdir") / "somefile.file")
 
     # Call LocalFileHandler
     filehandler = LocalFileHandler(
-        user_input=((Path("parentdir"),), None),
+        user_input=((pathlib.Path("parentdir"),), None),
         project="someproject",
         temporary_destination="temporarydestination",
         remote_destination="remote_destination",
     )
     expected_data_1 = {
-        (Path("remote_destination") / "parentdir" / "fileinparentdir.file").as_posix(): {
-            "path_raw": Path.cwd() / "parentdir" / "fileinparentdir.file",
-            "subpath": Path("remote_destination") / "parentdir",
+        (pathlib.Path("remote_destination") / "parentdir" / "fileinparentdir.file").as_posix(): {
+            "path_raw": pathlib.Path.cwd() / "parentdir" / "fileinparentdir.file",
+            "subpath": pathlib.Path("remote_destination") / "parentdir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
-                raw_file=Path("parentdir") / "fileinparentdir.file",
-                subpath=Path("remote_destination") / "parentdir",
+                raw_file=pathlib.Path("parentdir") / "fileinparentdir.file",
+                subpath=pathlib.Path("remote_destination") / "parentdir",
                 no_compression=False,
             ),
             "size_processed": 0,
             "overwrite": False,
             "checksum": "",
         },
-        (Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file").as_posix(): {
-            "path_raw": Path.cwd() / "parentdir" / "somedir" / "fileinsomedir.file",
-            "subpath": Path("remote_destination") / "parentdir" / "somedir",
+        (pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file").as_posix(): {
+            "path_raw": pathlib.Path.cwd() / "parentdir" / "somedir" / "fileinsomedir.file",
+            "subpath": pathlib.Path("remote_destination") / "parentdir" / "somedir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
-                raw_file=Path("parentdir") / "somedir" / "fileinsomedir.file",
-                subpath=Path("remote_destination") / "parentdir" / "somedir",
+                raw_file=pathlib.Path("parentdir") / "somedir" / "fileinsomedir.file",
+                subpath=pathlib.Path("remote_destination") / "parentdir" / "somedir",
                 no_compression=False,
             ),
             "size_processed": 0,
@@ -66,15 +66,15 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "checksum": "",
         },
         (
-            Path("remote_destination") / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file"
+            pathlib.Path("remote_destination") / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file"
         ).as_posix(): {
-            "path_raw": Path.cwd() / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file",
-            "subpath": Path("remote_destination") / "parentdir" / "somedir" / "subdir",
+            "path_raw": pathlib.Path.cwd() / "parentdir" / "somedir" / "subdir" / "fileinsubdir.file",
+            "subpath": pathlib.Path("remote_destination") / "parentdir" / "somedir" / "subdir",
             "size_raw": 0,
             "compressed": False,
             "path_processed": filehandler.create_encrypted_name(
-                raw_file=Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file",
-                subpath=Path("remote_destination") / "parentdir" / "somedir" / "subdir",
+                raw_file=pathlib.Path("parentdir") / "somedir" / "subdir" / "fileinsubdir.file",
+                subpath=pathlib.Path("remote_destination") / "parentdir" / "somedir" / "subdir",
                 no_compression=False,
             ),
             "size_processed": 0,


### PR DESCRIPTION
## Summary
- Build test directories and files using `pathlib.Path` instead of string paths
- Normalize expected keys with `Path(...).as_posix()` and use `Path.cwd()` for absolute paths

## Testing
- `pip install pyfakefs` *(failed: Could not find a version that satisfies the requirement pyfakefs)*
- `pytest tests/test_file_handler_local.py::test_localfilehandler_with_destination -q` *(failed: No module named 'pyfakefs')*

------
https://chatgpt.com/codex/tasks/task_b_68a84edab1c083269165c9a24d339643