### PR TITLE
refactor tests to use Path for token_path

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 from datetime import datetime
-from pathlib import Path
+import pathlib
 
 from requests_mock.mocker import Mocker
 import pytest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 from datetime import datetime
+from pathlib import Path
 
 from requests_mock.mocker import Mocker
 import pytest
@@ -17,6 +18,7 @@ MOCK_PASSWORD = "testpass"
 MOCK_2FA_CODE = "123456"
 MOCK_PARTIAL_AUTH_TOKEN = "partial_auth_token_12345"
 MOCK_AUTH_TOKEN = "final_auth_token_12345"
+TOKEN_PATH = Path("custom") / "path"
 
 
 ###### Test initialization ######
@@ -37,7 +39,7 @@ def test_init_auth_with_custom_parameters() -> None:
         auth = Auth(
             authenticate=False,
             force_renew_token=False,
-            token_path="/custom/path",
+            token_path=str(TOKEN_PATH),
             totp="123456",
             allow_group=True,
         )
@@ -78,7 +80,7 @@ def test_init_auth_with_authentication_custom_params() -> None:
         auth = Auth(
             authenticate=True,
             force_renew_token=False,
-            token_path="/custom/path",
+            token_path=str(TOKEN_PATH),
             totp=MOCK_2FA_CODE,
             allow_group=True,
         )
@@ -88,7 +90,7 @@ def test_init_auth_with_authentication_custom_params() -> None:
         mock_user_class.assert_called_once_with(
             force_renew_token=False,
             no_prompt=False,
-            token_path="/custom/path",
+            token_path=TOKEN_PATH.as_posix(),
             allow_group=True,
             totp=MOCK_2FA_CODE,
         )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -18,7 +18,7 @@ MOCK_PASSWORD = "testpass"
 MOCK_2FA_CODE = "123456"
 MOCK_PARTIAL_AUTH_TOKEN = "partial_auth_token_12345"
 MOCK_AUTH_TOKEN = "final_auth_token_12345"
-TOKEN_PATH = Path("custom") / "path"
+TOKEN_PATH = pathlib.Path("custom") / "path"
 
 
 ###### Test initialization ######
@@ -90,7 +90,7 @@ def test_init_auth_with_authentication_custom_params() -> None:
         mock_user_class.assert_called_once_with(
             force_renew_token=False,
             no_prompt=False,
-            token_path=TOKEN_PATH.as_posix(),
+            token_path=str(TOKEN_PATH),
             allow_group=True,
             totp=MOCK_2FA_CODE,
         )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 """Test the base module authentication functionality."""
 
 from unittest.mock import MagicMock, patch
-from pathlib import Path
+import pathlib 
 
 import pytest
 
@@ -17,7 +17,7 @@ MOCK_PARTIAL_AUTH_TOKEN = "partial_auth_token_12345"
 MOCK_AUTH_TOKEN = "final_auth_token_12345"
 MOCK_TOKEN_DICT = {"Authorization": f"Bearer {MOCK_AUTH_TOKEN}"}
 MOCK_PROJECT = "test_project_123"
-TOKEN_PATH = Path("custom") / "path"
+TOKEN_PATH = pathlib.Path("custom") / "path"
 
 
 ###### Test initialization without authentication ######
@@ -102,7 +102,7 @@ def test_init_base_class_with_authentication_custom_params(mock_user_class):
     mock_user_class.assert_called_once_with(
         force_renew_token=True,
         no_prompt=True,
-        token_path=TOKEN_PATH.as_posix(),
+        token_path=str(TOKEN_PATH),
         allow_group=True,
         totp=MOCK_2FA_CODE,
     )
@@ -215,7 +215,7 @@ def test_complete_authentication_flow_integration(mock_user_class):
     mock_user_class.assert_called_once_with(
         force_renew_token=True,
         no_prompt=True,
-        token_path=TOKEN_PATH.as_posix(),
+        token_path=str(TOKEN_PATH),
         allow_group=True,
         totp=MOCK_2FA_CODE,
     )
@@ -225,6 +225,6 @@ def test_complete_authentication_flow_integration(mock_user_class):
     assert base.project == MOCK_PROJECT
     assert base.method == "list"
     assert base.no_prompt is True
-    assert base.token_path == TOKEN_PATH.as_posix()
+    assert base.token_path == str(TOKEN_PATH)
     assert base.totp == MOCK_2FA_CODE
     assert base.stop_doing is False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,7 @@
 """Test the base module authentication functionality."""
 
 from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +17,7 @@ MOCK_PARTIAL_AUTH_TOKEN = "partial_auth_token_12345"
 MOCK_AUTH_TOKEN = "final_auth_token_12345"
 MOCK_TOKEN_DICT = {"Authorization": f"Bearer {MOCK_AUTH_TOKEN}"}
 MOCK_PROJECT = "test_project_123"
+TOKEN_PATH = Path("custom") / "path"
 
 
 ###### Test initialization without authentication ######
@@ -91,7 +93,7 @@ def test_init_base_class_with_authentication_custom_params(mock_user_class):
         authenticate=True,
         force_renew_token=True,
         no_prompt=True,
-        token_path="/custom/path",
+        token_path=str(TOKEN_PATH),
         allow_group=True,
         totp=MOCK_2FA_CODE,
     )
@@ -100,7 +102,7 @@ def test_init_base_class_with_authentication_custom_params(mock_user_class):
     mock_user_class.assert_called_once_with(
         force_renew_token=True,
         no_prompt=True,
-        token_path="/custom/path",
+        token_path=TOKEN_PATH.as_posix(),
         allow_group=True,
         totp=MOCK_2FA_CODE,
     )
@@ -204,7 +206,7 @@ def test_complete_authentication_flow_integration(mock_user_class):
         authenticate=True,
         force_renew_token=True,
         no_prompt=True,
-        token_path="/custom/path",
+        token_path=str(TOKEN_PATH),
         allow_group=True,
         totp=MOCK_2FA_CODE,
     )
@@ -213,7 +215,7 @@ def test_complete_authentication_flow_integration(mock_user_class):
     mock_user_class.assert_called_once_with(
         force_renew_token=True,
         no_prompt=True,
-        token_path="/custom/path",
+        token_path=TOKEN_PATH.as_posix(),
         allow_group=True,
         totp=MOCK_2FA_CODE,
     )
@@ -223,6 +225,6 @@ def test_complete_authentication_flow_integration(mock_user_class):
     assert base.project == MOCK_PROJECT
     assert base.method == "list"
     assert base.no_prompt is True
-    assert base.token_path == "/custom/path"
+    assert base.token_path == TOKEN_PATH.as_posix()
     assert base.totp == MOCK_2FA_CODE
     assert base.stop_doing is False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 """Test the base module authentication functionality."""
 
 from unittest.mock import MagicMock, patch
-import pathlib 
+import pathlib
 
 import pytest
 


### PR DESCRIPTION
## Summary
- replace hardcoded "/custom/path" strings with Path expressions in tests

------
https://chatgpt.com/codex/tasks/task_b_68a85a9279f88326848de2e06f3e9cc2