### PR TITLE
Use Path.home for DDSApp token path

### DIFF
--- a/gui_build/gui_standalone.py
+++ b/gui_build/gui_standalone.py
@@ -2,10 +2,10 @@
 This file is used to run the DDS GUI standalone for the executable.
 """
 
-from pathlib import Path
+import pathlib
 
 from dds_cli.dds_gui.app import DDSApp
 
 if __name__ == "__main__":
-    app = DDSApp(token_path=str(Path.home() / ".dds_cli_token"))
+    app = DDSApp(token_path=str(pathlib.Path.home() / ".dds_cli_token"))
     app.run()


### PR DESCRIPTION
## Summary
- use `Path.home()` to resolve DDSApp token path in GUI standalone script


------
https://chatgpt.com/codex/tasks/task_b_68a85a9707d48326bc7eda75937996bd