### PR TITLE
Use explicit home token path

### DIFF
--- a/dds_cli/dds_gui/dds_state_manager.py
+++ b/dds_cli/dds_gui/dds_state_manager.py
@@ -1,7 +1,7 @@
 """DDS State Manager"""
 
 from dataclasses import dataclass
-from pathlib import Path
+import pathlib
 
 from textual.reactive import reactive
 
@@ -135,7 +135,7 @@ class DDSStateManager:
     """
 
     # Default token path for CLI authentication token
-    token_path = str(Path.home() / ".dds_cli_token")
+    token_path = str(pathlib.Path.home() / ".dds_cli_token")
     # ------------------------------------------------------------
     # BASE STATES
     # ------------------------------------------------------------

--- a/dds_cli/dds_gui/dds_state_manager.py
+++ b/dds_cli/dds_gui/dds_state_manager.py
@@ -1,6 +1,7 @@
 """DDS State Manager"""
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from textual.reactive import reactive
 
@@ -133,8 +134,8 @@ class DDSStateManager:
 
     """
 
-    # TODO: Make this get the token path correctly
-    token_path = "~/.dds_cli_token"
+    # Default token path for CLI authentication token
+    token_path = str(Path.home() / ".dds_cli_token")
     # ------------------------------------------------------------
     # BASE STATES
     # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ensure GUI state manager uses the user's home directory for the CLI token file

------
https://chatgpt.com/codex/tasks/task_b_68a85af681b48326b93c41e5f76037ac