### PR TITLE
test: relax project info table border check

### DIFF
--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -57,7 +57,8 @@ returned_response_extend_deadline_ok: typing.Dict = {
 
 #########
 def check_table_proj_info(table_output):
-    assert "┏━━━━━" in table_output.out  # A table has generated
+    # A table has generated: check for any common border character.
+    assert any(ch in table_output.out for ch in ("┏", "┌", "+"))
     assert f"{returned_response_get_info['Project ID']}" in table_output.out
     assert f"{returned_response_get_info['Created by']}" in table_output.out
     assert f"{returned_response_get_info['Status']}" in table_output.out


### PR DESCRIPTION
## Summary
- make project info table assertion border-agnostic to handle various table formats

## Testing
- `pytest tests/test_project_status.py` *(fails: ModuleNotFoundError: No module named 'requests_mock')*
- `pip install requests-mock` *(fails: Could not find a version due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ad86b0353083268bfbbe8f5f7ef391