### PR TITLE
test: allow flexible table borders

### DIFF
--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -57,7 +57,8 @@ returned_response_extend_deadline_ok: typing.Dict = {
 
 #########
 def check_table_proj_info(table_output):
-    assert "┏━━━━━" in table_output.out  # A table has generated
+    assert "┏" in table_output.out  # A table has generated
+    assert any(char in table_output.out for char in ("┗", "└"))
     assert f"{returned_response_get_info['Project ID']}" in table_output.out
     assert f"{returned_response_get_info['Created by']}" in table_output.out
     assert f"{returned_response_get_info['Status']}" in table_output.out


### PR DESCRIPTION
## Summary
- relax project info table border assertions for cross-platform compatibility

## Testing
- `python - <<'PY'
import unittest.mock
import pytest
raise SystemExit(pytest.main(['tests/test_project_status.py::test_extend_deadline_confirmed_ok', '-q']))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68ad86bd2a4c8326a3515ae6a4c589ae