### PR TITLE
Expand table border assertion in test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -597,7 +597,7 @@ def test_print_or_page_multiple_rows() -> None:
     # There should be 100 rows in addition to the four border/header lines
     assert len(lines) - 4 == 100
     # Check that the table borders were printed
-    assert "┏" in rendered
+    assert any(ch in rendered for ch in ("┏", "┌", "+"))
     assert any(char in rendered for char in ("┗", "└"))
 
 


### PR DESCRIPTION
## Summary
- Expand top border assertion in test_print_or_page_multiple_rows to accept multiple characters

## Testing
- `pytest tests/test_utils.py::test_print_or_page_multiple_rows -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask -q` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68ad86c46ba88326a230fc9dcab87f37