### PR TITLE
test: support alternative table borders

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -573,7 +573,7 @@ def test_print_or_page() -> None:
 
     rendered = output.getvalue()
     # Ensure table borders were printed
-    assert "┏" in rendered
+    assert any(ch in rendered for ch in ("┏", "┌", "+"))
     # The bottom border may be rendered with either heavy (┗) or light (└) characters
     assert any(char in rendered for char in ("┗", "└"))
 


### PR DESCRIPTION
## Summary
- allow test_print_or_page to accept heavy, light, or ascii table top borders

## Testing
- `pytest tests/test_utils.py::test_print_or_page tests/test_utils.py::test_print_or_page_multiple_rows tests/test_utils.py::test_print_or_page_error -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install Flask==2.2.5 requests-mock==1.9.3 pyfakefs==5.8.0 textual==2.1.2 pytest==8.4.0 pytest-cov==3.0.0 pytest-asyncio==1.0.0` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5 (proxy 403))*

------
https://chatgpt.com/codex/tasks/task_b_68ad86c1a8ec8326b8440db19ad769d6