### PR TITLE
test: make stats table border check flexible

### DIFF
--- a/tests/test_superadmin_helper.py
+++ b/tests/test_superadmin_helper.py
@@ -231,9 +231,8 @@ def test_get_stats_print_tables(capsys: CaptureFixture):
             helper.get_stats()  # Get stats
 
     captured_output = capsys.readouterr()
-    assert "┏━━━━━" in captured_output.out
+    assert any(ch in captured_output.out for ch in ("┏", "┌", "+"))
     assert "┃ Date" in captured_output.out
-    assert "┡━━━━━" in captured_output.out
 
     # A header from first table
     assert "Researchers" in captured_output.out


### PR DESCRIPTION
## Summary
- allow flexible border characters when asserting superadmin stats tables

## Testing
- `pip install requests-mock==1.9.3` *(fails: Could not find a version that satisfies the requirement requests-mock==1.9.3)*
- `pytest tests/test_superadmin_helper.py::test_get_stats_print_tables -q` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_b_68ad86c04c908326862d06e1063b7a98