### PR TITLE
test: relax motd table matching

### DIFF
--- a/tests/test_motd_manager.py
+++ b/tests/test_motd_manager.py
@@ -1,6 +1,7 @@
 """Test the motd_manager module."""
 
 import logging
+import re
 from typing import Dict, List
 
 import pytest
@@ -88,19 +89,9 @@ def test_list_all_active_motds_table(capsys: CaptureFixture):
             mtdm.list_all_active_motds(table=True)  # Run active motds listing
 
     captured = capsys.readouterr()
-    assert (
-        "\n".join(
-            [
-                "┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓",
-                "┃ MOTD ID ┃ Message ┃ Created          ┃",
-                "┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩",
-                "│ 1       │ Test    │ 2022-08-05 08:31 │",
-                "│ 2       │ Test 2  │ 2022-08-05 08:54 │",
-                "└─────────┴─────────┴──────────────────┘",
-            ]
-        )
-        in captured.out
-    )
+    for motd in returned_dict["motds"]:
+        row_pattern = rf"{motd['MOTD ID']}.*{re.escape(motd['Message'])}.*{re.escape(motd['Created'])}"
+        assert re.search(row_pattern, captured.out, re.DOTALL)
 
 
 def test_list_all_active_motds_nottable(capsys: CaptureFixture):


### PR DESCRIPTION
## Summary
- use regex to allow flexible table row matching in MOTD tests

## Testing
- `pip install requests_mock -q` *(fails: Could not find a version that satisfies the requirement requests_mock)*
- `pytest tests/test_motd_manager.py::test_list_all_active_motds_table -q` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_b_68ad918c5a788326b10861b91ea5f6d4