### PR TITLE
Use POSIX paths in expected data for LocalFileHandler test

### DIFF
--- a/tests/test_file_handler_local.py
+++ b/tests/test_file_handler_local.py
@@ -39,7 +39,7 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
         remote_destination="remote_destination",
     )
     expected_data_1 = {
-        str(pathlib.Path("remote_destination") / "parentdir" / "fileinparentdir.file"): {
+        (pathlib.Path("remote_destination") / "parentdir" / "fileinparentdir.file").as_posix(): {
             "path_raw": pathlib.Path.cwd() / "parentdir" / "fileinparentdir.file",
             "subpath": pathlib.Path("remote_destination") / "parentdir",
             "size_raw": 0,
@@ -53,7 +53,7 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "overwrite": False,
             "checksum": "",
         },
-        str(pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file"): {
+        (pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file").as_posix(): {
             "path_raw": pathlib.Path.cwd() / "parentdir" / "somedir" / "fileinsomedir.file",
             "subpath": pathlib.Path("remote_destination") / "parentdir" / "somedir",
             "size_raw": 0,
@@ -67,13 +67,13 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "overwrite": False,
             "checksum": "",
         },
-        str(
+        (
             pathlib.Path("remote_destination")
             / "parentdir"
             / "somedir"
             / "subdir"
             / "fileinsubdir.file"
-        ): {
+        ).as_posix(): {
             "path_raw": pathlib.Path.cwd()
             / "parentdir"
             / "somedir"

--- a/tests/test_file_handler_local.py
+++ b/tests/test_file_handler_local.py
@@ -53,7 +53,9 @@ def test_localfilehandler_with_destination(fs: FakeFilesystem):
             "overwrite": False,
             "checksum": "",
         },
-        (pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file").as_posix(): {
+        (
+            pathlib.Path("remote_destination") / "parentdir" / "somedir" / "fileinsomedir.file"
+        ).as_posix(): {
             "path_raw": pathlib.Path.cwd() / "parentdir" / "somedir" / "fileinsomedir.file",
             "subpath": pathlib.Path("remote_destination") / "parentdir" / "somedir",
             "size_raw": 0,


### PR DESCRIPTION
## Summary
- normalize expected path keys using `Path.as_posix` for cross-platform compatibility

## Testing
- `pytest tests/test_file_handler_local.py::test_localfilehandler_with_destination -q` *(fails: No module named 'pyfakefs')*


------
https://chatgpt.com/codex/tasks/task_b_68ada638f7b0832681b902f2ed30435a