### PR TITLE
Fix missing backtick in conflict option message

### DIFF
--- a/dds_cli/__main__.py
+++ b/dds_cli/__main__.py
@@ -784,7 +784,7 @@ def delete_user(click_ctx, email, self, is_invite):
         proceed_deletion = True
     else:
         if is_invite and self:
-            LOG.error("You cannot specify both `--self` and `--is-invite. Choose one.")
+            LOG.error("You cannot specify both `--self` and `--is-invite`. Choose one.")
             sys.exit(0)
 
         if not self and not email:


### PR DESCRIPTION
## Summary
- close backtick around `--is-invite` in conflicting option message

------
https://chatgpt.com/codex/tasks/task_b_68aedaf5f390832692a1a7f0006d306c