### PR TITLE
docs: fix typo in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,6 @@ currently being supported with security updates.
 
 ## Reporting security issues
 
-Please send us your report privately via: **email comming**
+Please send us your report privately via: **email coming**
 
 DO NOT file a public issue.


### PR DESCRIPTION
## Summary
- fix typo in SECURITY.md

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyfakefs')*


------
https://chatgpt.com/codex/tasks/task_b_68aedaf863988326b17d969f58fb2aef