### PR TITLE
docs: correct user privileges typo in examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -89,7 +89,7 @@ There are two possible configurations for the Two-Factor Authentication:
 End authenticated session ("Log out")
 ---------------------------------------
 
-In order to avoid unauthorized users accessing the DDS (and thereby your user-privilages and data) via your account, we recommend that you manually end your session after having run the operations with ``dds-cli``. To end the session, run:
+In order to avoid unauthorized users accessing the DDS (and thereby your user-privileges and data) via your account, we recommend that you manually end your session after having run the operations with ``dds-cli``. To end the session, run:
 
 .. code-block:: 
 


### PR DESCRIPTION
## Summary
- fix typo in docs/examples.rst: user-privilages -> user-privileges

------
https://chatgpt.com/codex/tasks/task_b_68aedafa34a08326b78e348f42fb6815