### PR TITLE
Fix grammar in base class docstring

### DIFF
--- a/dds_cli/base.py
+++ b/dds_cli/base.py
@@ -1,4 +1,4 @@
-"""Base class for the DDS CLI. Verifies the users access to the DDS."""
+"""Base class for the DDS CLI. Verifies the user's access to the DDS."""
 
 ###############################################################################
 # IMPORTS ########################################################### IMPORTS #


### PR DESCRIPTION
## Summary
- fix grammar in `DDSBaseClass` docstring to use "user's access"


------
https://chatgpt.com/codex/tasks/task_b_68aedafc9c608326ae851f69806670d8