### PR TITLE
Fix error handling bug in GUI authentication

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -462,3 +462,4 @@ _Empty sprint_
 - Workflow: Add action to run pytest on Windows ([#734](https://github.com/ScilifelabDataCentre/dds_cli/pull/734))
 - Add Dardel-related information to the documentation ([#774](https://github.com/ScilifelabDataCentre/dds_cli/pull/774))
 - Implement Project Info in GUI ([#838](https://github.com/ScilifelabDataCentre/dds_cli/pull/838))
+- Fix error handling bug in GUI authentication ([#839](https://github.com/ScilifelabDataCentre/dds_cli/pull/839))

--- a/dds_cli/dds_gui/pages/authentication/authentication_form.py
+++ b/dds_cli/dds_gui/pages/authentication/authentication_form.py
@@ -68,6 +68,8 @@ class AuthenticationForm(Container):
         except (
             dds_cli.exceptions.AuthenticationError,
             dds_cli.exceptions.ApiRequestError,
+            dds_cli.exceptions.ApiResponseError,
+            dds_cli.exceptions.DDSCLIException,
         ) as error:
             self.notify(f"Error: {error}", severity="error")
             self.auth = None
@@ -84,7 +86,12 @@ class AuthenticationForm(Container):
             )
             self.notify("Successfully authenticated.")
             self.app.set_auth_status(True)
-        except dds_cli.exceptions.AuthenticationError as error:
+        except (
+            dds_cli.exceptions.AuthenticationError,
+            dds_cli.exceptions.ApiRequestError,
+            dds_cli.exceptions.ApiResponseError,
+            dds_cli.exceptions.DDSCLIException,
+        ) as error:
             self.notify(f"Error: {error}", severity="error", timeout=10)
         self.close_modal()
 

--- a/dds_cli/dds_gui/pages/authentication/authentication_form.py
+++ b/dds_cli/dds_gui/pages/authentication/authentication_form.py
@@ -76,7 +76,6 @@ class AuthenticationForm(Container):
             dds_cli.exceptions.DDSCLIException,
         ) as error:
             self.notify(f"Error: {error}", severity="error")
-            self.auth = None
             return False
         return True
 

--- a/dds_cli/dds_gui/pages/authentication/authentication_form.py
+++ b/dds_cli/dds_gui/pages/authentication/authentication_form.py
@@ -48,8 +48,8 @@ class AuthenticationForm(Container):
     def on_button_pressed(self, event: events.Click) -> None:
         """Handle button presses."""
         if event.button.id == "send-2fa-code":
-            self.authenticate_user_credentials()
-            if self.auth:
+            success = self.authenticate_user_credentials()
+            if success:
                 self.query_one("#dds-auth-form").remove()
                 self.query_one("#dds-auth-form-container").mount(
                     TwoFactorFormFields(id="dds-2fa-form")
@@ -57,10 +57,14 @@ class AuthenticationForm(Container):
         if event.button.id == "login":
             self.confirm_2factor_code()
 
-    def authenticate_user_credentials(self) -> None:
+    def authenticate_user_credentials(self) -> bool:
         """Authenticate the user credentials."""
         username = self.query_one("#username").value
         password = self.query_one("#password").value
+
+        if not username or not password:
+            self.notify("Error: Username and password are required.", severity="error", timeout=10)
+            return False
 
         try:
             self.partial_auth_token, self.secondfactor_method = self.auth.login(username, password)
@@ -73,10 +77,16 @@ class AuthenticationForm(Container):
         ) as error:
             self.notify(f"Error: {error}", severity="error")
             self.auth = None
+            return False
+        return True
 
     def confirm_2factor_code(self) -> None:
         """Confirm the 2FA code."""
         code = self.query_one("#code").value
+
+        if not code:
+            self.notify("Error: 2FA code is required.", severity="error", timeout=10)
+            return
 
         try:
             self.auth.confirm_twofactor(

--- a/tests/gui_tests/test_authentication.py
+++ b/tests/gui_tests/test_authentication.py
@@ -591,128 +591,13 @@ async def test_reauthentication_invalid_credentials_error_handling() -> None:
 
 
 # =================================================================================
-# Comprehensive Exception Tests - All Auth Class Exceptions
+# 2FA Confirmation Exception Tests - Missing Exception Handling
 # =================================================================================
 
 
 @pytest.mark.asyncio
-async def test_no_prompt_authentication_error() -> None:
-    """Test AuthenticationError when no-prompt is used during authentication."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise AuthenticationError for no-prompt
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
-            "Authentication not possible when running with --no-prompt. "
-            "Please run the `dds auth login` command and authenticate interactively."
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after no-prompt error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_unicode_encode_error() -> None:
-    """Test ApiRequestError when username/password contains invalid characters."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise ApiRequestError for UnicodeEncodeError
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
-            "The entered username or password seems to contain invalid characters. Please try again."
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials with invalid characters
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user_with_émojis"
-            password_inputs.first().value = "test_password_with_special_chars"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after Unicode error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_totp_not_enabled_error() -> None:
-    """Test AuthenticationError when TOTP is used but not enabled."""
+async def test_2fa_json_decode_error() -> None:
+    """Test ApiResponseError when API returns invalid JSON during 2FA confirmation."""
 
     with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
@@ -726,12 +611,9 @@ async def test_totp_not_enabled_error() -> None:
         # Mock Auth in AuthenticationForm
         mock_auth_form_instance = MagicMock()
         mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")  # HOTP, not TOTP
-        mock_auth_form_instance.confirm_twofactor.side_effect = (
-            dds_cli.exceptions.AuthenticationError(
-                "Authentication failed, you have not yet activated one-time "
-                "authentication codes from authenticator app."
-            )
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = dds_cli.exceptions.ApiResponseError(
+            "Response code: 200. The request did not return a valid JSON response. Details: Expecting value: line 1 column 1 (char 0)"
         )
 
         app = DDSApp(token_path=str(TOKEN_PATH))
@@ -762,8 +644,8 @@ async def test_totp_not_enabled_error() -> None:
             code_inputs = app.query("Input#code")
             assert len(code_inputs) > 0, "2FA code field should be present"
 
-            # Fill TOTP code (but user has HOTP enabled)
-            code_inputs.first().value = "123456"  # TOTP format
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
             await pilot.pause()
 
             # Click login button to submit 2FA code
@@ -772,13 +654,346 @@ async def test_totp_not_enabled_error() -> None:
             await pilot.pause()
 
             # Verify error notification was shown and modal closed
-            assert len(app.screen_stack) == 1, "Login modal should be closed after TOTP error"
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA JSON decode error"
             assert not app.auth_status, "Authentication status should remain False"
 
 
 @pytest.mark.asyncio
-async def test_empty_2fa_code_error() -> None:
-    """Test AuthenticationError when 2FA code is empty."""
+async def test_2fa_connection_error() -> None:
+    """Test ApiRequestError when connection fails during 2FA confirmation."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = dds_cli.exceptions.ApiRequestError(
+            "Failed to authenticate with second factor: The database seems to be down -- \nConnection refused"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA connection error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_2fa_timeout_error() -> None:
+    """Test ApiRequestError when request times out during 2FA confirmation."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = dds_cli.exceptions.ApiRequestError(
+            "Failed to authenticate with second factor: The request timed out."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA timeout error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_2fa_bad_request_error() -> None:
+    """Test DDSCLIException when API returns 400 Bad Request during 2FA confirmation."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = dds_cli.exceptions.DDSCLIException(
+            "Failed to authenticate with second factor: Invalid 2FA code provided"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA bad request error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_2fa_forbidden_error() -> None:
+    """Test DDSCLIException when API returns 403 Forbidden during 2FA confirmation."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = dds_cli.exceptions.DDSCLIException(
+            "Failed to authenticate with second factor: Access denied"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA forbidden error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_2fa_internal_server_error() -> None:
+    """Test ApiResponseError when API returns 500 Internal Server Error during 2FA confirmation."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = dds_cli.exceptions.ApiResponseError(
+            "Failed to authenticate with second factor: Internal server error occurred"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA internal server error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_2fa_missing_token_error() -> None:
+    """Test AuthenticationError when token is missing from 2FA response."""
 
     with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
@@ -794,9 +1009,7 @@ async def test_empty_2fa_code_error() -> None:
         mock_auth_form_class.return_value = mock_auth_form_instance
         mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
         mock_auth_form_instance.confirm_twofactor.side_effect = (
-            dds_cli.exceptions.AuthenticationError(
-                "Exited due to no one-time authentication code entered."
-            )
+            dds_cli.exceptions.AuthenticationError("Missing token in authentication response.")
         )
 
         app = DDSApp(token_path=str(TOKEN_PATH))
@@ -827,357 +1040,18 @@ async def test_empty_2fa_code_error() -> None:
             code_inputs = app.query("Input#code")
             assert len(code_inputs) > 0, "2FA code field should be present"
 
-            # Leave 2FA code empty
-            code_inputs.first().value = ""
+            # Fill 2FA code
+            code_inputs.first().value = "12345678"
             await pilot.pause()
 
-            # Click login button to submit empty 2FA code
+            # Click login button to submit 2FA code
             login_buttons = app.query("Button#login")
             await pilot.click(login_buttons.first())
             await pilot.pause()
 
             # Verify error notification was shown and modal closed
-            assert len(app.screen_stack) == 1, "Login modal should be closed after empty 2FA error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-
-@pytest.mark.asyncio
-async def test_json_decode_error() -> None:
-    """Test ApiResponseError when API returns invalid JSON."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise ApiResponseError for JSON decode error
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiResponseError(
-            "Response code: 200. The request did not return a valid JSON response. Details: Expecting value: line 1 column 1 (char 0)"
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
+            # The app should still be running and not crashed
             assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after JSON decode error"
+                len(app.screen_stack) == 1
+            ), "Login modal should be closed after 2FA missing token error"
             assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_connection_error() -> None:
-    """Test ApiRequestError when connection fails."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise ApiRequestError for connection error
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
-            "Failed to authenticate user: The database seems to be down -- \nConnection refused"
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after connection error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_timeout_error() -> None:
-    """Test ApiRequestError when request times out."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise ApiRequestError for timeout
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
-            "Failed to authenticate user: The request timed out."
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after timeout error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_bad_request_error() -> None:
-    """Test DDSCLIException when API returns 400 Bad Request."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise DDSCLIException for bad request
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.DDSCLIException(
-            "Failed to authenticate user: Invalid credentials provided"
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after bad request error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_forbidden_error() -> None:
-    """Test DDSCLIException when API returns 403 Forbidden."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise DDSCLIException for forbidden
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.DDSCLIException(
-            "Failed to authenticate user: Access denied"
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after forbidden error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"
-
-
-@pytest.mark.asyncio
-async def test_internal_server_error() -> None:
-    """Test ApiResponseError when API returns 500 Internal Server Error."""
-
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
-        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
-    ) as mock_auth_form_class:
-
-        # Mock DataLister to prevent authentication attempts
-        mock_data_lister_instance = MagicMock()
-        mock_data_lister_class.return_value = mock_data_lister_instance
-        mock_data_lister_instance.list_projects.return_value = []
-
-        # Mock Auth in AuthenticationForm to raise ApiResponseError for internal server error
-        mock_auth_form_instance = MagicMock()
-        mock_auth_form_class.return_value = mock_auth_form_instance
-        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiResponseError(
-            "Failed to authenticate user: Internal server error occurred"
-        )
-
-        app = DDSApp(token_path=str(TOKEN_PATH))
-
-        async with app.run_test() as pilot:
-            app.set_auth_status(False)
-            await pilot.pause()
-
-            # Push login modal
-            login_modal = LoginModal()
-            app.push_screen(login_modal)
-            await pilot.pause()
-
-            # Fill credentials
-            username_inputs = app.query("Input#username")
-            password_inputs = app.query("Input#password")
-
-            username_inputs.first().value = "test_user"
-            password_inputs.first().value = "test_password"
-            await pilot.pause()
-
-            # Click "Send 2FA code" button to trigger authentication
-            send_2fa_buttons = app.query("Button#send-2fa-code")
-            await pilot.click(send_2fa_buttons.first())
-            await pilot.pause()
-
-            # Verify error notification was shown
-            assert (
-                len(app.screen_stack) > 1
-            ), "Login modal should still be displayed after internal server error"
-            assert not app.auth_status, "Authentication status should remain False"
-
-            # Verify the form is still in login state (not switched to 2FA)
-            username_inputs_after = app.query("Input#username")
-            password_inputs_after = app.query("Input#password")
-            assert len(username_inputs_after) > 0, "Username field should still be present"
-            assert len(password_inputs_after) > 0, "Password field should still be present"

--- a/tests/gui_tests/test_authentication.py
+++ b/tests/gui_tests/test_authentication.py
@@ -303,7 +303,7 @@ async def test_keyboard_navigation() -> None:
 async def test_invalid_credentials_error_handling() -> None:
     """Test that invalid credentials show error notification and don't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -363,7 +363,7 @@ async def test_invalid_credentials_error_handling() -> None:
 async def test_invalid_2fa_code_error_handling() -> None:
     """Test that invalid 2FA code shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -427,7 +427,7 @@ async def test_invalid_2fa_code_error_handling() -> None:
 async def test_network_error_handling() -> None:
     """Test that network/API errors show error notification and don't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -485,7 +485,7 @@ async def test_network_error_handling() -> None:
 async def test_empty_credentials_error_handling() -> None:
     """Test that empty credentials show error notification and don't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -543,7 +543,7 @@ async def test_empty_credentials_error_handling() -> None:
 async def test_reauthentication_invalid_credentials_error_handling() -> None:
     """Test that invalid credentials in reauthentication show error notification and don't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -617,7 +617,7 @@ async def test_reauthentication_invalid_credentials_error_handling() -> None:
 async def test_empty_field_error_handling(field, value, error_msg):
     """Test that empty fields show error notification and don't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -673,7 +673,7 @@ async def test_empty_field_error_handling(field, value, error_msg):
 async def test_empty_2fa_code_error_handling() -> None:
     """Test that empty 2FA code shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -739,7 +739,7 @@ async def test_empty_2fa_code_error_handling() -> None:
 async def test_login_json_decode_error() -> None:
     """Test that JSON decode error during login shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -792,7 +792,7 @@ async def test_login_json_decode_error() -> None:
 async def test_login_internal_server_error() -> None:
     """Test that 500 Internal Server Error during login shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -843,7 +843,7 @@ async def test_login_internal_server_error() -> None:
 async def test_login_bad_request_error() -> None:
     """Test that 400 Bad Request during login shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -896,7 +896,7 @@ async def test_login_bad_request_error() -> None:
 async def test_login_forbidden_error() -> None:
     """Test that 403 Forbidden during login shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -949,7 +949,7 @@ async def test_login_forbidden_error() -> None:
 async def test_no_prompt_authentication_error() -> None:
     """Test that no-prompt authentication error shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1002,7 +1002,7 @@ async def test_no_prompt_authentication_error() -> None:
 async def test_totp_not_enabled_error() -> None:
     """Test that TOTP not enabled error shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1053,7 +1053,7 @@ async def test_totp_not_enabled_error() -> None:
 async def test_unicode_decode_error() -> None:
     """Test that Unicode decode error during login shows error notification and doesn't crash the GUI."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1109,7 +1109,7 @@ async def test_unicode_decode_error() -> None:
 async def test_2fa_json_decode_error() -> None:
     """Test ApiResponseError when API returns invalid JSON during 2FA confirmation."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1175,7 +1175,7 @@ async def test_2fa_json_decode_error() -> None:
 async def test_2fa_connection_error() -> None:
     """Test ApiRequestError when connection fails during 2FA confirmation."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1241,7 +1241,7 @@ async def test_2fa_connection_error() -> None:
 async def test_2fa_timeout_error() -> None:
     """Test ApiRequestError when request times out during 2FA confirmation."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1307,7 +1307,7 @@ async def test_2fa_timeout_error() -> None:
 async def test_2fa_bad_request_error() -> None:
     """Test DDSCLIException when API returns 400 Bad Request during 2FA confirmation."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1373,7 +1373,7 @@ async def test_2fa_bad_request_error() -> None:
 async def test_2fa_forbidden_error() -> None:
     """Test DDSCLIException when API returns 403 Forbidden during 2FA confirmation."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1439,7 +1439,7 @@ async def test_2fa_forbidden_error() -> None:
 async def test_2fa_internal_server_error() -> None:
     """Test ApiResponseError when API returns 500 Internal Server Error during 2FA confirmation."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 
@@ -1505,7 +1505,7 @@ async def test_2fa_internal_server_error() -> None:
 async def test_2fa_missing_token_error() -> None:
     """Test AuthenticationError when token is missing from 2FA response."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+    with patch("dds_cli.data_lister.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
 

--- a/tests/gui_tests/test_authentication.py
+++ b/tests/gui_tests/test_authentication.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import dds_cli.exceptions
 from dds_cli.dds_gui.app import DDSApp
 from dds_cli.dds_gui.pages.authentication.modals.login_modal import LoginModal
 from dds_cli.dds_gui.pages.authentication.modals.logout_modal import LogoutModal
@@ -57,16 +58,9 @@ async def test_auth_status_ui_switching() -> None:
 async def test_login_modal_ui_workflow() -> None:
     """Test 2FA UI workflow: form switching and field appearance."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.Auth") as mock_auth_class, patch(
-        "dds_cli.dds_gui.dds_state_manager.DataLister"
-    ) as mock_data_lister_class, patch(
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
-
-        mock_auth_instance = MagicMock()
-        mock_auth_class.return_value = mock_auth_instance
-        mock_auth_instance.login.return_value = ("partial_token_456", "TOTP")
-        mock_auth_instance.confirm_twofactor.return_value = None
 
         # Mock DataLister to prevent authentication attempts
         mock_data_lister_instance = MagicMock()
@@ -136,12 +130,7 @@ async def test_login_modal_ui_workflow() -> None:
 async def test_logout_modal_interactions() -> None:
     """Test logout modal UI interactions."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.Auth") as mock_auth_class, patch(
-        "dds_cli.dds_gui.dds_state_manager.DataLister"
-    ) as mock_data_lister_class:
-
-        mock_auth_instance = MagicMock()
-        mock_auth_class.return_value = mock_auth_instance
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class:
 
         # Mock DataLister to prevent authentication attempts
         mock_data_lister_instance = MagicMock()
@@ -190,16 +179,9 @@ async def test_logout_modal_interactions() -> None:
 async def test_reauthentication_modal_form_interactions() -> None:
     """Test reauthentication modal form interactions."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.Auth") as mock_auth_class, patch(
-        "dds_cli.dds_gui.dds_state_manager.DataLister"
-    ) as mock_data_lister_class, patch(
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
-
-        mock_auth_instance = MagicMock()
-        mock_auth_class.return_value = mock_auth_instance
-        mock_auth_instance.login.return_value = ("partial_token_456", "TOTP")
-        mock_auth_instance.confirm_twofactor.return_value = None
 
         # Mock DataLister to prevent authentication attempts
         mock_data_lister_instance = MagicMock()
@@ -267,14 +249,9 @@ async def test_reauthentication_modal_form_interactions() -> None:
 async def test_keyboard_navigation() -> None:
     """Test keyboard navigation in authentication forms."""
 
-    with patch("dds_cli.dds_gui.dds_state_manager.Auth") as mock_auth_class, patch(
-        "dds_cli.dds_gui.dds_state_manager.DataLister"
-    ) as mock_data_lister_class, patch(
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
         "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
     ) as mock_auth_form_class:
-
-        mock_auth_instance = MagicMock()
-        mock_auth_class.return_value = mock_auth_instance
 
         # Mock DataLister to prevent authentication attempts
         mock_data_lister_instance = MagicMock()
@@ -304,3 +281,903 @@ async def test_keyboard_navigation() -> None:
                 # Test escape to cancel
                 await pilot.press("escape")
                 await pilot.pause()
+
+
+# =================================================================================
+# Error Handling Tests
+# =================================================================================
+
+
+@pytest.mark.asyncio
+async def test_invalid_credentials_error_handling() -> None:
+    """Test that invalid credentials show error notification and don't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise AuthenticationError
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            "Invalid username or password"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill invalid credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "invalid_user"
+            password_inputs.first().value = "invalid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            # The app should still be running and not crashed
+            assert len(app.screen_stack) > 1, "Login modal should still be displayed after error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_invalid_2fa_code_error_handling() -> None:
+    """Test that invalid 2FA code shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "TOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = (
+            dds_cli.exceptions.AuthenticationError("Invalid 2FA code")
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill invalid 2FA code
+            code_inputs.first().value = "000000"
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            # The app should still be running and not crashed
+            assert len(app.screen_stack) == 1, "Login modal should be closed after 2FA error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_network_error_handling() -> None:
+    """Test that network/API errors show error notification and don't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise ApiRequestError
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
+            "Network connection failed"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after network error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_empty_credentials_error_handling() -> None:
+    """Test that empty credentials show error notification and don't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise AuthenticationError for empty credentials
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            "Non-empty username needed to be able to authenticate."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Leave credentials empty
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = ""
+            password_inputs.first().value = ""
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after empty credentials error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_reauthentication_invalid_credentials_error_handling() -> None:
+    """Test that invalid credentials in reauthentication show error notification and don't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise AuthenticationError
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            "Invalid username or password"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(True)  # Start as authenticated
+            await pilot.pause()
+
+            # Push reauthentication modal
+            reauth_modal = ReAuthenticateModal()
+            app.push_screen(reauth_modal)
+            await pilot.pause()
+
+            # Fill invalid credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "invalid_user"
+            password_inputs.first().value = "invalid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            # The app should still be running and not crashed
+            assert (
+                len(app.screen_stack) > 1
+            ), "Reauthentication modal should still be displayed after error"
+            assert app.auth_status, "Authentication status should remain True (original state)"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+# =================================================================================
+# Comprehensive Exception Tests - All Auth Class Exceptions
+# =================================================================================
+
+
+@pytest.mark.asyncio
+async def test_no_prompt_authentication_error() -> None:
+    """Test AuthenticationError when no-prompt is used during authentication."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise AuthenticationError for no-prompt
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            "Authentication not possible when running with --no-prompt. "
+            "Please run the `dds auth login` command and authenticate interactively."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after no-prompt error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_unicode_encode_error() -> None:
+    """Test ApiRequestError when username/password contains invalid characters."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise ApiRequestError for UnicodeEncodeError
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
+            "The entered username or password seems to contain invalid characters. Please try again."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials with invalid characters
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user_with_émojis"
+            password_inputs.first().value = "test_password_with_special_chars"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after Unicode error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_totp_not_enabled_error() -> None:
+    """Test AuthenticationError when TOTP is used but not enabled."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")  # HOTP, not TOTP
+        mock_auth_form_instance.confirm_twofactor.side_effect = (
+            dds_cli.exceptions.AuthenticationError(
+                "Authentication failed, you have not yet activated one-time "
+                "authentication codes from authenticator app."
+            )
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Fill TOTP code (but user has HOTP enabled)
+            code_inputs.first().value = "123456"  # TOTP format
+            await pilot.pause()
+
+            # Click login button to submit 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            assert len(app.screen_stack) == 1, "Login modal should be closed after TOTP error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_empty_2fa_code_error() -> None:
+    """Test AuthenticationError when 2FA code is empty."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = (
+            dds_cli.exceptions.AuthenticationError(
+                "Exited due to no one-time authentication code entered."
+            )
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill valid credentials to get to 2FA step
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify 2FA form is now displayed
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+
+            # Leave 2FA code empty
+            code_inputs.first().value = ""
+            await pilot.pause()
+
+            # Click login button to submit empty 2FA code
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown and modal closed
+            assert len(app.screen_stack) == 1, "Login modal should be closed after empty 2FA error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+@pytest.mark.asyncio
+async def test_json_decode_error() -> None:
+    """Test ApiResponseError when API returns invalid JSON."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise ApiResponseError for JSON decode error
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiResponseError(
+            "Response code: 200. The request did not return a valid JSON response. Details: Expecting value: line 1 column 1 (char 0)"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after JSON decode error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_connection_error() -> None:
+    """Test ApiRequestError when connection fails."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise ApiRequestError for connection error
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
+            "Failed to authenticate user: The database seems to be down -- \nConnection refused"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after connection error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_timeout_error() -> None:
+    """Test ApiRequestError when request times out."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise ApiRequestError for timeout
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
+            "Failed to authenticate user: The request timed out."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after timeout error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_bad_request_error() -> None:
+    """Test DDSCLIException when API returns 400 Bad Request."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise DDSCLIException for bad request
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.DDSCLIException(
+            "Failed to authenticate user: Invalid credentials provided"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after bad request error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_forbidden_error() -> None:
+    """Test DDSCLIException when API returns 403 Forbidden."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise DDSCLIException for forbidden
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.DDSCLIException(
+            "Failed to authenticate user: Access denied"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after forbidden error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_internal_server_error() -> None:
+    """Test ApiResponseError when API returns 500 Internal Server Error."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock DataLister to prevent authentication attempts
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        # Mock Auth in AuthenticationForm to raise ApiResponseError for internal server error
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiResponseError(
+            "Failed to authenticate user: Internal server error occurred"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Push login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Click "Send 2FA code" button to trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error notification was shown
+            assert (
+                len(app.screen_stack) > 1
+            ), "Login modal should still be displayed after internal server error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify the form is still in login state (not switched to 2FA)
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"

--- a/tests/gui_tests/test_authentication.py
+++ b/tests/gui_tests/test_authentication.py
@@ -591,6 +591,505 @@ async def test_reauthentication_invalid_credentials_error_handling() -> None:
 
 
 # =================================================================================
+# Empty Field Validation Tests
+# =================================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,error_msg",
+    [
+        ("username", "", "Non-empty username needed to be able to authenticate."),
+        ("password", "test_password", "Non-empty password needed to be able to authenticate."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_empty_field_error_handling(field, value, error_msg):
+    """Test that empty fields show error notification and don't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            error_msg
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill form with empty field
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+
+            username_inputs.first().value = "test_user" if field == "password" else value
+            password_inputs.first().value = "test_password" if field == "username" else value
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert (
+                len(app.screen_stack) == 2
+            ), f"Login modal should remain open after empty {field} error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify form fields still present
+            username_inputs_after = app.query("Input#username")
+            password_inputs_after = app.query("Input#password")
+            assert len(username_inputs_after) > 0, "Username field should still be present"
+            assert len(password_inputs_after) > 0, "Password field should still be present"
+
+
+@pytest.mark.asyncio
+async def test_empty_2fa_code_error_handling() -> None:
+    """Test that empty 2FA code shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.return_value = ("partial_token_456", "HOTP")
+        mock_auth_form_instance.confirm_twofactor.side_effect = (
+            dds_cli.exceptions.AuthenticationError(
+                "Exited due to no one-time authentication code entered."
+            )
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal and fill credentials
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "valid_user"
+            password_inputs.first().value = "valid_password"
+            await pilot.pause()
+
+            # Go to 2FA step
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Submit empty 2FA code
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) > 0, "2FA code field should be present"
+            code_inputs.first().value = ""  # Empty 2FA code
+            await pilot.pause()
+
+            login_buttons = app.query("Button#login")
+            await pilot.click(login_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert (
+                len(app.screen_stack) == 2
+            ), "Login modal should remain open after empty 2FA code error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+
+# =================================================================================
+# Additional Login Exception Tests - Missing Coverage
+# =================================================================================
+
+
+@pytest.mark.asyncio
+async def test_login_json_decode_error() -> None:
+    """Test that JSON decode error during login shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiResponseError(
+            "Response code: 200. The request did not return a valid JSON response. Details: Expecting value: line 1 column 1 (char 0)"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert (
+                len(app.screen_stack) == 2
+            ), "Login modal should remain open after JSON decode error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_login_internal_server_error() -> None:
+    """Test that 500 Internal Server Error during login shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiResponseError(
+            "Failed to authenticate user: Internal server error occurred"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert len(app.screen_stack) == 2, "Login modal should remain open after server error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_login_bad_request_error() -> None:
+    """Test that 400 Bad Request during login shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.DDSCLIException(
+            "Failed to authenticate user: Invalid request parameters"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert (
+                len(app.screen_stack) == 2
+            ), "Login modal should remain open after bad request error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_login_forbidden_error() -> None:
+    """Test that 403 Forbidden during login shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.DDSCLIException(
+            "Failed to authenticate user: Access forbidden"
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert (
+                len(app.screen_stack) == 2
+            ), "Login modal should remain open after forbidden error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_no_prompt_authentication_error() -> None:
+    """Test that no-prompt authentication error shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            "Authentication not possible when running with --no-prompt. Please run the `dds auth login` command and authenticate interactively."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert (
+                len(app.screen_stack) == 2
+            ), "Login modal should remain open after no-prompt error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_totp_not_enabled_error() -> None:
+    """Test that TOTP not enabled error shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.AuthenticationError(
+            "TOTP is not enabled for this user. Please use email-based 2FA instead."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user"
+            password_inputs.first().value = "test_password"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert len(app.screen_stack) == 2, "Login modal should remain open after TOTP error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+@pytest.mark.asyncio
+async def test_unicode_decode_error() -> None:
+    """Test that Unicode decode error during login shows error notification and doesn't crash the GUI."""
+
+    with patch("dds_cli.dds_gui.dds_state_manager.DataLister") as mock_data_lister_class, patch(
+        "dds_cli.dds_gui.pages.authentication.authentication_form.Auth"
+    ) as mock_auth_form_class:
+
+        # Mock setup
+        mock_data_lister_instance = MagicMock()
+        mock_data_lister_class.return_value = mock_data_lister_instance
+        mock_data_lister_instance.list_projects.return_value = []
+
+        mock_auth_form_instance = MagicMock()
+        mock_auth_form_class.return_value = mock_auth_form_instance
+        mock_auth_form_instance.login.side_effect = dds_cli.exceptions.ApiRequestError(
+            "The entered username or password seems to contain invalid characters. Please try again."
+        )
+
+        app = DDSApp(token_path=str(TOKEN_PATH))
+
+        async with app.run_test() as pilot:
+            app.set_auth_status(False)
+            await pilot.pause()
+
+            # Setup login modal
+            login_modal = LoginModal()
+            app.push_screen(login_modal)
+            await pilot.pause()
+
+            # Fill credentials with invalid characters
+            username_inputs = app.query("Input#username")
+            password_inputs = app.query("Input#password")
+            username_inputs.first().value = "test_user_with_ñ"
+            password_inputs.first().value = "test_password_with_é"
+            await pilot.pause()
+
+            # Trigger authentication
+            send_2fa_buttons = app.query("Button#send-2fa-code")
+            await pilot.click(send_2fa_buttons.first())
+            await pilot.pause()
+
+            # Verify error handling
+            assert len(app.screen_stack) == 2, "Login modal should remain open after Unicode error"
+            assert not app.auth_status, "Authentication status should remain False"
+
+            # Verify 2FA form is not shown
+            code_inputs = app.query("Input#code")
+            assert len(code_inputs) == 0, "2FA code field should not be present after error"
+
+
+# =================================================================================
 # 2FA Confirmation Exception Tests - Missing Exception Handling
 # =================================================================================
 


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [x] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)

### Summary

_Describe what the PR changes and why._

- Add error handling for wrong/empty credentials
- Add error handling for wrong/empty 2fa code
- Update tests 

### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

HMS-2492

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

Added additional tests. To test the GUI manually, run `textual run gui_build/gui_standalone.py` and enter "invalid" credentials and 2fa codes.

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
