### PR TITLE
Downgrade windows version to 2022

### DIFF
--- a/.github/workflows/pytest-cli.yml
+++ b/.github/workflows/pytest-cli.yml
@@ -46,7 +46,7 @@ jobs:
           files: ./coverage/report.xml
 
   build-on-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v3

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -473,3 +473,4 @@ _Empty sprint_
 
 - Bump cryptography library from 42.0.4 to 44.0.1 to solve vulnerabities ([#845](https://github.com/ScilifelabDataCentre/dds_cli/pull/845))
 - Add loading to GUI project listing ([#850](https://github.com/ScilifelabDataCentre/dds_cli/pull/850))
+- Revert Windows version to 2022 in pytest workflow ([#853](https://github.com/ScilifelabDataCentre/dds_cli/pull/853))

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -473,4 +473,7 @@ _Empty sprint_
 
 - Bump cryptography library from 42.0.4 to 44.0.1 to solve vulnerabities ([#845](https://github.com/ScilifelabDataCentre/dds_cli/pull/845))
 - Add loading to GUI project listing ([#850](https://github.com/ScilifelabDataCentre/dds_cli/pull/850))
+
+## 2025-09-29 - 2025-10-10
+
 - Revert Windows version to 2022 in pytest workflow ([#853](https://github.com/ScilifelabDataCentre/dds_cli/pull/853))


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [x] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)

### Summary

_Describe what the PR changes and why._

Revert the windows version in the pytest workflow from latest to 2022 to fix failing Textual tests that appeard after the upgrade to using latest. 

### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

HMS-2540

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
