### PR TITLE
chore(crypto): drop deprecated backend= argument from HKDF

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -542,3 +542,4 @@ _Empty sprint_
 - HMS-2655 fix assets names ([#954](https://github.com/ScilifelabDataCentre/dds_cli/pull/954))
 - Update dependency cryptography to v46.0.7 [SECURITY] ([#947](https://github.com/ScilifelabDataCentre/dds_cli/pull/947))
 - Update dependency cryptography to v48 [SECURITY] ([#957](https://github.com/ScilifelabDataCentre/dds_cli/pull/957))
+- Drop deprecated backend= argument from HKDF ([#958](https://github.com/ScilifelabDataCentre/dds_cli/pull/958))

--- a/dds_cli/file_encryptor.py
+++ b/dds_cli/file_encryptor.py
@@ -12,7 +12,6 @@ import pathlib
 import traceback
 
 # Installed
-from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
@@ -55,12 +54,14 @@ class ECDHKeyHandler:
 
         # Generate shared key and derive encryption key with salt
         shared_key = (my_private).exchange(peer_public)
+        # Note: HKDF used to take a `backend=` argument; it has been a deprecated
+        # no-op since cryptography 35 and is slated for hard removal. We rely on
+        # the default backend implicitly.
         derived_shared_key = hkdf.HKDF(
             algorithm=hashes.SHA256(),
             length=32,
             salt=salt,
             info=b"",
-            backend=backends.default_backend(),
         ).derive(shared_key)
 
         return derived_shared_key, salt.hex().upper()


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [ ] Add relevant information to the sections below ([Summary](#summary) etc)
- [ ] Rebase or merge the latest `dev` (or other targeted branch)
- [ ] Update documentation if needed
- [ ] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) if needed
- [ ] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [ ] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/style_guidelines.md)
- [ ] Perform a self-review: read the diff as if reviewing someone else's code
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)

### Summary

The `backend` keyword on cryptography's HKDF (and the `cryptography.hazmat.backends.default_backend` symbol) has been a deprecated no-op since cryptography 35 — there has only ever been one backend. The deprecation has been progressively louder across major versions and the symbol is slated for hard removal.

Removing the argument and the unused import now keeps the code forward-compatible with the upcoming cryptography releases that finally remove the symbol, and removes a small piece of legacy syntax. No behavior change.

### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
