### PR TITLE
Fix silent download truncation being misreported as crypto failure

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -549,3 +549,7 @@ _Empty sprint_
 - Update dependency rich to v15 ([#949](https://github.com/ScilifelabDataCentre/dds_cli/pull/949))
 - Update dependency jwcrypto to v1.5.7 ([#943](https://github.com/ScilifelabDataCentre/dds_cli/pull/943))
 - New version v2.14.3 ([#960](https://github.com/ScilifelabDataCentre/dds_cli/pull/960))
+
+## 2026-06-08 - 2026-06-19
+
+- Fix silent download truncation being misreported as crypto failure ([#962](https://github.com/ScilifelabDataCentre/dds_cli/pull/962))

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -151,7 +151,17 @@ class DataGetter(base.DDSBaseClass):
         # `get()` now verifies the on-disk byte count against `size_stored`
         # internally and only returns True if the file matches. If we reach
         # this branch, the encrypted-size check has already passed.
+        # Defensive guard: make the contract explicit so a future refactor of
+        # get() that breaks the size guarantee fails loudly here rather than
+        # silently proceeding to decryption and surfacing as failed_op="crypto".
         if file_downloaded:
+            actual_size = file_info["path_downloaded"].stat().st_size
+            expected_size = file_info["size_stored"]
+            if actual_size != expected_size:
+                raise RuntimeError(
+                    f"get() returned True but size mismatch for '{file_name_in_db}': "
+                    f"expected {expected_size} bytes, got {actual_size} bytes"
+                )
             db_updated, message = self.update_db(file=file)
             LOG.debug(
                 "API call: database updated for file '%s': %s",

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -148,29 +148,10 @@ class DataGetter(base.DDSBaseClass):
 
         LOG.debug("File '%s' downloaded: %s", file_name_in_db, file_downloaded)
 
-        file_size_verified = False
-
+        # `get()` now verifies the on-disk byte count against `size_stored`
+        # internally and only returns True if the file matches. If we reach
+        # this branch, the encrypted-size check has already passed.
         if file_downloaded:
-            ## File size verification
-            expected_size = file_info["size_stored"]
-            actual_size = file_info["path_downloaded"].stat().st_size
-
-            if actual_size == expected_size:
-                file_size_verified = True
-                LOG.debug(
-                    "Downloaded file '%s' size matches expected size: %s bytes.",
-                    file_name_in_db,
-                    expected_size,
-                )
-            else:
-                LOG.debug(
-                    "Downloaded file '%s' size mismatch: expected %s bytes, got %s bytes. Not decrypting.",
-                    file_name_in_db,
-                    expected_size,
-                    actual_size,
-                )
-
-        if file_size_verified:
             db_updated, message = self.update_db(file=file)
             LOG.debug(
                 "API call: database updated for file '%s': %s",
@@ -239,18 +220,27 @@ class DataGetter(base.DDSBaseClass):
 
     @update_status
     def get(self, file, progress, task):
-        """Download files from the cloud."""
+        """Download files from the cloud and verify the byte count."""
         downloaded = False
         error = ""
-        file_local = self.filehandler.data[file]["path_downloaded"]
-        file_remote = self.filehandler.data[file]["url"]
-        file_name_in_db = escape(str(self.filehandler.data[file]["name_in_db"]))
+        file_info = self.filehandler.data[file]
+        file_local = file_info["path_downloaded"]
+        file_remote = file_info["url"]
+        # The encrypted size on the bucket — what we expect on disk after the GET.
+        # `size_original` is the plaintext size and is checked later, after decryption.
+        expected_size = file_info["size_stored"]
+        file_name_in_db = escape(str(file_info["name_in_db"]))
 
+        # ChunkedEncodingError is included so that silent stream truncation
+        # (raised manually below) hits the same backoff/retry path as a real
+        # network error. Without it, a truncated body looked like a successful
+        # download to requests/urllib3 and the retry loop never fired.
         retryable_exceptions = (
             requests.exceptions.ConnectTimeout,
             requests.exceptions.ReadTimeout,
             requests.exceptions.Timeout,
             requests.exceptions.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
         )
 
         max_retries = constants.DOWNLOAD_MAX_RETRIES
@@ -262,7 +252,13 @@ class DataGetter(base.DDSBaseClass):
             error = ""
             if attempt > 1:
                 progress.reset(task, completed=0)
+                # Drop the partial file from the previous attempt before retrying.
+                # We don't (yet) support Range-based resume, so a fresh GET starts
+                # at byte zero; leaving the old bytes around would just confuse
+                # the size check below.
+                self._remove_partial(file_local, file_name_in_db)
 
+            bytes_written = 0
             try:
                 with requests.get(
                     file_remote,
@@ -270,10 +266,42 @@ class DataGetter(base.DDSBaseClass):
                     timeout=(constants.CONNECT_TIMEOUT, constants.READ_TIMEOUT),
                 ) as req:
                     req.raise_for_status()
+                    # Server-advertised body size. AWS S3 sets this on every GET,
+                    # but S3-compatible backends behind a proxy may use chunked
+                    # transfer encoding (no Content-Length) or send a malformed
+                    # value. Treat both as "unknown" and rely on the size_stored
+                    # check below to catch truncation in that case.
+                    try:
+                        content_length = int(req.headers.get("Content-Length", 0))
+                    except (TypeError, ValueError):
+                        content_length = 0
                     with file_local.open(mode="wb") as new_file:
                         for chunk in req.iter_content(chunk_size=FileSegment.SEGMENT_SIZE_CIPHER):
                             progress.update(task, advance=len(chunk))
                             new_file.write(chunk)
+                            bytes_written += len(chunk)
+
+                # Guard against silent truncation: requests/urllib3 do not
+                # validate that bytes received == Content-Length. A clean TCP
+                # FIN mid-stream otherwise looks like an EOF and the loop exits
+                # successfully. Raise so the retry path catches us.
+                if content_length and bytes_written != content_length:
+                    raise requests.exceptions.ChunkedEncodingError(
+                        f"Truncated download for '{file_name_in_db}': "
+                        f"got {bytes_written} of {content_length} bytes"
+                    )
+
+                # Cross-check against the size DDS recorded for the encrypted
+                # blob. This used to live in download_and_verify() (outside the
+                # retry loop), which made truncation unrecoverable in a single
+                # run. Doing it here means a mismatch retries like any other
+                # transport error.
+                actual_size = file_local.stat().st_size
+                if actual_size != expected_size:
+                    raise requests.exceptions.ChunkedEncodingError(
+                        f"Size mismatch for '{file_name_in_db}': "
+                        f"expected {expected_size} bytes, got {actual_size} bytes"
+                    )
             except (requests.exceptions.HTTPError, *retryable_exceptions) as err:
                 if (
                     isinstance(err, requests.exceptions.HTTPError)
@@ -295,6 +323,11 @@ class DataGetter(base.DDSBaseClass):
                     wait *= backoff_factor
             else:
                 downloaded = True
+                LOG.debug(
+                    "Downloaded file '%s' size matches expected size: %s bytes.",
+                    file_name_in_db,
+                    expected_size,
+                )
                 break
 
         if not downloaded and error:
@@ -306,8 +339,26 @@ class DataGetter(base.DDSBaseClass):
                 max_retries,
                 error,
             )
+            # Don't leave a partial blob on disk after we've given up — it just
+            # consumes space and risks being mistaken for a complete file.
+            self._remove_partial(file_local, file_name_in_db)
 
         return downloaded, error
+
+    @staticmethod
+    def _remove_partial(file_local, file_name_in_db):
+        """Delete a partial download. Best-effort — never raises."""
+        try:
+            file_local.unlink(missing_ok=True)
+        except OSError as unlink_err:
+            # File-locking on Windows occasionally blocks unlink while the
+            # progress bar still holds the path; we don't want this to mask
+            # the real download error, so just log and move on.
+            LOG.debug(
+                "Could not remove partial download for '%s': %s",
+                file_name_in_db,
+                unlink_err,
+            )
 
     @update_status
     def update_db(self, file):

--- a/dds_cli/data_getter.py
+++ b/dds_cli/data_getter.py
@@ -349,6 +349,13 @@ class DataGetter(base.DDSBaseClass):
                 max_retries,
                 error,
             )
+            LOG.warning(
+                "Download of '%s' could not be completed after %d attempts. "
+                "Please ensure your internet connection is stable and that your "
+                "computer does not enter sleep mode during large file transfers.",
+                file_name_in_db,
+                max_retries,
+            )
             # Don't leave a partial blob on disk after we've given up — it just
             # consumes space and risks being mistaken for a complete file.
             self._remove_partial(file_local, file_name_in_db)

--- a/tests/test_data_getter.py
+++ b/tests/test_data_getter.py
@@ -2,7 +2,9 @@
 
 # IMPORTS ######################################################################
 
+import logging
 import pathlib
+import pytest
 import requests
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -465,4 +467,59 @@ def test_get_tolerates_missing_or_malformed_content_length(monkeypatch, tmp_path
         )
 
         assert downloaded is True, f"failed for Content-Length={header_value!r}: {message}"
+
+
+def test_get_warns_user_about_connection_on_exhausted_retries(monkeypatch, tmp_path, caplog):
+    """After all retries fail, get() must emit a user-facing warning suggesting
+    the user check their internet connection and sleep settings."""
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=100)
+
+    monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 2)
+    monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
+
+    truncated_response = _ok_response(body=b"data")
+    truncated_response.headers.get.return_value = 100
+    monkeypatch.setattr("dds_cli.data_getter.requests.get", lambda *_, **__: truncated_response)
+
+    with caplog.at_level(logging.WARNING, logger="dds_cli.data_getter"):
+        DataGetter.get.__wrapped__(getter, file=file_name, progress=MagicMock(), task=1)
+
+    warning_texts = " ".join(
+        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+    )
+    assert "internet connection" in warning_texts.lower()
+    assert "sleep" in warning_texts.lower()
+
+
+def test_download_and_verify_raises_on_size_contract_violation(tmp_path):
+    """download_and_verify() must raise RuntimeError when get() returns True but
+    the on-disk file doesn't match size_stored.
+
+    This guards against a future get() refactor that silently breaks the size
+    guarantee and would otherwise let a truncated blob reach decryption,
+    reintroducing the failed_op='crypto' misattribution from the May 2026 incident.
+    """
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+
+    # Write a file that is the wrong size (2 bytes; size_stored expects 100).
+    file_path.write_bytes(b"xx")
+
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=100)
+    getter.filehandler.data[file_name]["size_original"] = 80
+    getter.silent = False
+
+    # get() incorrectly claims success despite the on-disk size mismatch.
+    getter.get = MagicMock(return_value=(True, ""))
+
+    progress = MagicMock()
+    progress.add_task.return_value = 1
+
+    # Bypass @verify_proceed and @subpath_required to call the raw function directly.
+    with pytest.raises(RuntimeError, match="get\\(\\) returned True but size mismatch"):
+        DataGetter.download_and_verify.__wrapped__.__wrapped__(
+            getter, file=file_name, progress=progress
+        )
         assert message == ""

--- a/tests/test_data_getter.py
+++ b/tests/test_data_getter.py
@@ -486,9 +486,7 @@ def test_get_warns_user_about_connection_on_exhausted_retries(monkeypatch, tmp_p
     with caplog.at_level(logging.WARNING, logger="dds_cli.data_getter"):
         DataGetter.get.__wrapped__(getter, file=file_name, progress=MagicMock(), task=1)
 
-    warning_texts = " ".join(
-        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
-    )
+    warning_texts = " ".join(r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
     assert "internet connection" in warning_texts.lower()
     assert "sleep" in warning_texts.lower()
 

--- a/tests/test_data_getter.py
+++ b/tests/test_data_getter.py
@@ -14,8 +14,13 @@ from dds_cli import constants
 # HELPERS ######################################################################
 
 
-def _prepare_data_getter(file_name, download_path=None):
-    """Mock a DataGetter instance with a filehandler containing a single file entry."""
+def _prepare_data_getter(file_name, download_path=None, size_stored=4):
+    """Mock a DataGetter instance with a filehandler containing a single file entry.
+
+    `size_stored` defaults to 4 to match the canonical ``b"data"`` body used by most
+    tests below; the byte-count check inside ``get()`` only passes when the on-disk
+    size equals this value.
+    """
     # Create DataGetter instance without running __init__
     dg = DataGetter.__new__(DataGetter)
 
@@ -31,10 +36,27 @@ def _prepare_data_getter(file_name, download_path=None):
                 "path_downloaded": pathlib.Path(download_path or file_name),
                 "url": "https://example.com/file",
                 "name_in_db": file_name,
+                "size_stored": size_stored,
             }
         }
     )
     return dg
+
+
+def _ok_response(body=b"data"):
+    """Build a mock requests.Response that streams ``body`` as a single chunk.
+
+    Sets a Content-Length header matching the body length so the truncation
+    check inside ``get()`` is satisfied. Tests that want to simulate a
+    truncated response should override ``headers.get`` themselves.
+    """
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+    mock_response.iter_content.return_value = [body]
+    mock_response.raise_for_status.return_value = None
+    mock_response.headers.get.return_value = len(body)
+    return mock_response
 
 
 # TESTS ########################################################################
@@ -54,13 +76,7 @@ def test_get_uses_timeout(monkeypatch, tmp_path):
 
     # Create mock objects
     progress = MagicMock()  # needed for get method but doesn't invoke real progress
-    mock_response = MagicMock()
-
-    # Define the mock return values
-    mock_response.__enter__.return_value = mock_response
-    mock_response.__exit__.return_value = False
-    mock_response.iter_content.return_value = [b"data"]  # Simulate content chunks
-    mock_response.raise_for_status.return_value = None  # Used in download to check for HTTP errors
+    mock_response = _ok_response()
 
     # Mock the requests.get method to return the mock_response
     mock_get = MagicMock(return_value=mock_response)
@@ -147,11 +163,7 @@ def test_get_retries_on_connection_error(monkeypatch, tmp_path):
     monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 3)
     monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
 
-    mock_response = MagicMock()
-    mock_response.__enter__.return_value = mock_response
-    mock_response.__exit__.return_value = False
-    mock_response.iter_content.return_value = [b"data"]
-    mock_response.raise_for_status.return_value = None
+    mock_response = _ok_response()
 
     call_count = 0
 
@@ -235,11 +247,7 @@ def test_get_retries_on_http_500(monkeypatch, tmp_path):
     mock_500_response = MagicMock()
     mock_500_response.status_code = 500
 
-    mock_ok_response = MagicMock()
-    mock_ok_response.__enter__.return_value = mock_ok_response
-    mock_ok_response.__exit__.return_value = False
-    mock_ok_response.iter_content.return_value = [b"data"]
-    mock_ok_response.raise_for_status.return_value = None
+    mock_ok_response = _ok_response()
 
     call_count = 0
 
@@ -289,11 +297,7 @@ def test_get_progress_reset_only_on_retry(monkeypatch, tmp_path):
     monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 3)
     monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
 
-    mock_response = MagicMock()
-    mock_response.__enter__.return_value = mock_response
-    mock_response.__exit__.return_value = False
-    mock_response.iter_content.return_value = [b"data"]
-    mock_response.raise_for_status.return_value = None
+    mock_response = _ok_response()
 
     call_count = 0
 
@@ -312,3 +316,153 @@ def test_get_progress_reset_only_on_retry(monkeypatch, tmp_path):
     DataGetter.get.__wrapped__(getter, file=file_name, progress=progress, task=task)
 
     assert progress.reset.call_count == 2
+
+
+def test_get_detects_truncated_stream_via_content_length(monkeypatch, tmp_path):
+    """A clean TCP close with fewer bytes than Content-Length must trigger a retry.
+
+    Reproduces the failure mode from the May 2026 ngisthlm02415 incident:
+    requests/urllib3 happily report a "successful" download even when the body
+    is short, so ``get()`` has to validate the byte count itself.
+    """
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+    # Server says 100 bytes, body delivers 4 — mimics a connection drop
+    # mid-stream where the FIN arrives before the full payload.
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=100)
+
+    monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 3)
+    monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
+
+    truncated_response = _ok_response(body=b"data")
+    truncated_response.headers.get.return_value = 100  # advertised, not delivered
+
+    monkeypatch.setattr("dds_cli.data_getter.requests.get", lambda *_, **__: truncated_response)
+
+    downloaded, message = DataGetter.get.__wrapped__(
+        getter, file=file_name, progress=MagicMock(), task=1
+    )
+
+    # The retry path engaged on every attempt and ultimately gave up.
+    assert downloaded is False
+    assert "Truncated download" in message
+    assert "attempt 1/3" in message
+
+
+def test_get_detects_size_mismatch_against_size_stored(monkeypatch, tmp_path):
+    """If the body size matches Content-Length but not size_stored, still fail.
+
+    This catches the case where a misbehaving S3-compatible backend serves a
+    Content-Length that disagrees with what DDS recorded — we trust the DDS
+    metadata as the source of truth.
+    """
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+    # DDS expects 100 bytes; the proxy reports and delivers 4 — they agree
+    # with each other but disagree with the catalogue.
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=100)
+
+    monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 2)
+    monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
+
+    # Content-Length matches the 4-byte body, so the truncation guard passes;
+    # the size_stored comparison is the one that has to catch this.
+    consistent_short_response = _ok_response(body=b"data")  # headers.get returns 4
+
+    monkeypatch.setattr(
+        "dds_cli.data_getter.requests.get", lambda *_, **__: consistent_short_response
+    )
+
+    downloaded, message = DataGetter.get.__wrapped__(
+        getter, file=file_name, progress=MagicMock(), task=1
+    )
+
+    assert downloaded is False
+    assert "Size mismatch" in message
+
+
+def test_get_cleans_up_partial_file_on_failure(monkeypatch, tmp_path):
+    """After exhausting retries, the truncated blob must not be left on disk."""
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=100)
+
+    monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 2)
+    monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
+
+    truncated_response = _ok_response(body=b"data")
+    truncated_response.headers.get.return_value = 100
+
+    monkeypatch.setattr("dds_cli.data_getter.requests.get", lambda *_, **__: truncated_response)
+
+    DataGetter.get.__wrapped__(getter, file=file_name, progress=MagicMock(), task=1)
+
+    # The point: don't leave a useless 4-byte file masquerading as a download.
+    assert not file_path.exists()
+
+
+def test_get_retries_on_truncation_and_eventually_succeeds(monkeypatch, tmp_path):
+    """A retry after a truncated attempt should produce a complete file."""
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=4)
+
+    monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 3)
+    monkeypatch.setattr(constants, "DOWNLOAD_INITIAL_WAIT", 0)
+
+    # First attempt: server claims 4 bytes but only delivers 2 — truncation.
+    truncated = MagicMock()
+    truncated.__enter__.return_value = truncated
+    truncated.__exit__.return_value = False
+    truncated.iter_content.return_value = [b"da"]
+    truncated.raise_for_status.return_value = None
+    truncated.headers.get.return_value = 4
+
+    # Second attempt: clean 4-byte response.
+    full = _ok_response(body=b"data")
+
+    responses = iter([truncated, full])
+    monkeypatch.setattr("dds_cli.data_getter.requests.get", lambda *_, **__: next(responses))
+
+    downloaded, message = DataGetter.get.__wrapped__(
+        getter, file=file_name, progress=MagicMock(), task=1
+    )
+
+    assert downloaded is True
+    assert message == ""
+    assert file_path.read_bytes() == b"data"
+
+
+def test_get_tolerates_missing_or_malformed_content_length(monkeypatch, tmp_path):
+    """Content-Length absent / chunked / garbled must not crash get().
+
+    AWS S3 always returns a clean integer, but S3-compatible backends
+    sometimes use Transfer-Encoding: chunked (no Content-Length header) or
+    sit behind a proxy that rewrites headers. In those cases the
+    Content-Length truncation guard is skipped and we fall back to the
+    size_stored byte-count check, which still catches truncation.
+    """
+    file_name = "file.bin"
+    file_path = tmp_path / file_name
+    # body length matches size_stored, so size_stored check passes;
+    # this test asserts we don't crash on the int() parse alone.
+    getter = _prepare_data_getter(file_name=file_name, download_path=file_path, size_stored=4)
+
+    monkeypatch.setattr(constants, "DOWNLOAD_MAX_RETRIES", 1)
+
+    # Each entry is what req.headers.get("Content-Length", 0) might return
+    # from a misbehaving server: missing (default 0 substituted), chunked
+    # responses surface as None, and garbled values like "abc" come from
+    # broken proxies that concatenate or rewrite headers.
+    for header_value in (0, None, "abc", "12, 12"):
+        response = _ok_response(body=b"data")
+        response.headers.get.return_value = header_value
+
+        monkeypatch.setattr("dds_cli.data_getter.requests.get", lambda *_, **__: response)
+
+        downloaded, message = DataGetter.get.__wrapped__(
+            getter, file=file_name, progress=MagicMock(), task=1
+        )
+
+        assert downloaded is True, f"failed for Content-Length={header_value!r}: {message}"
+        assert message == ""


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [x] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)

### Summary

Reproduces and fixes the failure mode seen in the May 2026 ngisthlm02415 support ticket where six large files (10-180 GB) ended up labelled failed_op=\"crypto\" despite the crypto layer never being invoked.

Root cause: requests/urllib3 do not validate Content-Length against bytes received by iter_content(). A clean TCP FIN mid-stream looked like a successful download, the retry loop in get() never engaged, and the size-mismatch check in download_and_verify() (outside the retry loop) just gave up and skipped decryption.

1) get() validates bytes_written against Content-Length and raises ChunkedEncodingError on mismatch, so silent truncation hits the existing backoff/retry path.
2) The on-disk size cross-check against size_stored moves into get() so it is also covered by retries.
3) failed_op is now set to \"get\" via @update_status when truncation is detected, instead of falling back to \"crypto\". 
4) Partial downloads are unlinked between retries and after final failure.

Tests: four new cases covering Content-Length truncation, size_stored mismatch, partial-file cleanup, and recovery on retry.


### Related Issue/Ticket

[[HMS-2658](https://scilifelab.atlassian.net/browse/HMS-2658)[HMS-2658](https://scilifelab.atlassian.net/browse/HMS-2658)](https://scilifelab.atlassian.net/browse/HMS-2658)

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.


[HMS-2658]: https://scilifelab.atlassian.net/browse/HMS-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ