### PR TITLE
Add MANIFEST.in to include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -554,3 +554,4 @@ _Empty sprint_
 
 - Fix silent download truncation being misreported as crypto failure ([#962](https://github.com/ScilifelabDataCentre/dds_cli/pull/962))
 - Update dependency sphinx-click to v4.4.0 ([#901](https://github.com/ScilifelabDataCentre/dds_cli/pull/901))
+- Add MANIFEST.in to include requirements.txt in sdist, fixing Bioconda build ([#966](https://github.com/ScilifelabDataCentre/dds_cli/pull/966))


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [x] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] Verify that all checks and tests have passed

### Summary

I am trying to add this to bioconda (see https://github.com/bioconda/bioconda-recipes/pull/64333), but it currently fails to build there, because `requirements.txt` is not in the sdist, but setup.py requires it.

This change makes sure it gets bundled with the rest of the files

### Related Issue/Ticket

