### PR TITLE
Skip publish and guard SARIF upload on fork PRs

### DIFF
--- a/.github/workflows/snyk-scan-cli.yml
+++ b/.github/workflows/snyk-scan-cli.yml
@@ -32,16 +32,25 @@ jobs:
       security-events: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python@v1.0.0
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: code test
           args: --sarif-file-output=snyk.sarif
+      - name: Check Snyk SARIF exists
+        id: check-sarif
+        run: |
+          if [ -f snyk.sarif ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
       - name: Upload result to GitHub Code Scanning
+        if: steps.check-sarif.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/test-pypi-cli.yml
+++ b/.github/workflows/test-pypi-cli.yml
@@ -10,6 +10,7 @@ on:
     branches: [dev]
 jobs:
   build-n-publish:
+    if: github.repository == 'ScilifelabDataCentre/dds_cli'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +31,6 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish dist to TestPyPI
-        if: github.repository == 'ScilifelabDataCentre/dds_cli'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print_hash: true

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -554,3 +554,4 @@ _Empty sprint_
 
 - Fix silent download truncation being misreported as crypto failure ([#962](https://github.com/ScilifelabDataCentre/dds_cli/pull/962))
 - Update dependency sphinx-click to v4.4.0 ([#901](https://github.com/ScilifelabDataCentre/dds_cli/pull/901))
+- Skip publish and guard SARIF upload on fork PRs ([#969](https://github.com/ScilifelabDataCentre/dds_cli/pull/969))


### PR DESCRIPTION
- test-pypi-cli: move repo check to job level to prevent OIDC attempt when triggered by fork pull requests
- snyk-scan-cli: add SARIF existence check before upload step to handle missing file when SNYK_TOKEN is unavailable on forks
- snyk-scan-cli: pin snyk/actions/python and actions/checkout to versioned tags instead of @master

## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [ ] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_cli/blob/dev/docs/procedures/new_release.md)

### Summary

Fix two workflow failures triggered by fork pull requests.

**test-pypi-cli.yml**: The `pypa/gh-action-pypi-publish` action attempts
OIDC even when a password is provided. Fork PRs don't get OIDC tokens,
causing the build-n-publish job to fail. Moved the repository guard from
the step level to the job level so the entire job is skipped for forks
before OIDC is attempted.

**snyk-scan-cli.yml**: When `SNYK_TOKEN` is unavailable (fork PRs don't
have access to secrets), Snyk exits without writing `snyk.sarif`. The
upload step then failed with "Path does not exist". Added an existence
check step and gated the upload on it, matching the pattern already used
in `dds_web`. Also pinned `snyk/actions/python` and `actions/checkout`
from `@master` to versioned tags.

### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
